### PR TITLE
Handle short spectral blocks and add regression test

### DIFF
--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.cpp
@@ -1,0 +1,137 @@
+#include "SpectralEngine.h"
+
+void SpectralEngine::setSampleRate(double sr)
+{
+    sampleRate = sr;
+#ifdef SAMURISE_USE_RUBBERBAND
+    stretcher.reset(new RubberBand::RubberBandStretcher(
+        sr, 1, RubberBand::RubberBandStretcher::OptionProcessRealTime |
+            RubberBand::RubberBandStretcher::OptionPitchHighConsistency));
+#endif
+}
+
+//==============================================================================
+void SpectralEngine::process(juce::AudioBuffer<float>& buffer, int numSamples,
+                             double, int)
+{
+#ifdef SAMURISE_USE_RUBBERBAND
+    if (stretcher)
+    {
+        stretcher->setPitchScale(pitchRatio);
+        float* chans[2] = {
+            buffer.getWritePointer(0),
+            buffer.getNumChannels() > 1 ? buffer.getWritePointer(1) : buffer.getWritePointer(0)
+        };
+        stretcher->process(chans, (size_t)numSamples, false);
+        stretcher->retrieve(chans, (size_t)numSamples);
+        return;
+    }
+#endif
+
+    const int fftSize = fft.getSize();
+    const int hopSize = fftSize / 4; // 75% overlap for smoother OLA
+
+    if ((int)fftBuffer.size() < 2 * fftSize)
+        fftBuffer.resize(2 * fftSize, 0.0f);
+    if ((int)dest.size() < 2 * fftSize)
+        dest.resize(2 * fftSize, 0.0f);
+
+    const int bins = fftSize / 2;
+    if ((int)prevInPhase.size() < bins + 1)
+    {
+        prevInPhase.assign(bins + 1, 0.0f);
+        prevOutPhase.assign(bins + 1, 0.0f);
+        prevMag.assign(bins + 1, 0.0f);
+    }
+
+    const float freqPerBin = (float)sampleRate / (float)fftSize;
+    const float expPhase = juce::MathConstants<float>::twoPi * hopSize / (float)fftSize;
+
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+    {
+        if (accum.getNumSamples() < numSamples + fftSize)
+            accum.setSize(1, numSamples + fftSize, false, false, true);
+        else if (accum.getNumSamples() > numSamples + fftSize)
+            accum.setSize(1, numSamples + fftSize, false, false, true);
+        accum.clear();
+
+        const float* read = buffer.getReadPointer(ch);
+        bool ranFrame = false;
+        auto processFrame = [&](const float* src, int validSamples, int pos)
+        {
+            std::fill(fftBuffer.begin(), fftBuffer.end(), 0.0f);
+            if (validSamples > 0)
+                std::memcpy(fftBuffer.data(), src, (size_t)validSamples * sizeof(float));
+
+            window.multiplyWithWindowingTable(fftBuffer.data(), fftSize);
+            fft.performRealOnlyForwardTransform(fftBuffer.data());
+
+            std::fill(dest.begin(), dest.end(), 0.0f);
+            for (int i = 0; i < bins; ++i)
+            {
+                float freq = i * freqPerBin;
+                if (freq > cutoff) continue;
+
+                float re = fftBuffer[2 * i];
+                float im = fftBuffer[2 * i + 1];
+                float m = std::sqrt(re * re + im * im);
+                float phase = std::atan2(im, re);
+
+                prevMag[i] = 0.7f * prevMag[i] + 0.3f * m;
+
+                float delta = phase - prevInPhase[i];
+                prevInPhase[i] = phase;
+                delta -= expPhase * i;
+                delta = std::fmod(delta + juce::MathConstants<float>::pi,
+                                  juce::MathConstants<float>::twoPi) -
+                        juce::MathConstants<float>::pi;
+                float trueFreq = (i + delta / expPhase) * pitchRatio;
+                int base = (int)trueFreq;
+                float frac = trueFreq - (float)base;
+                if (base < bins)
+                {
+                    float mag = prevMag[i];
+                    float phase0 = prevOutPhase[base] + expPhase * trueFreq;
+                    prevOutPhase[base] = phase0;
+                    float cos0 = std::cos(phase0);
+                    float sin0 = std::sin(phase0);
+                    dest[2 * base]     += mag * (1.0f - frac) * cos0;
+                    dest[2 * base + 1] += mag * (1.0f - frac) * sin0;
+
+                    if (base + 1 < bins)
+                    {
+                        float phase1 = prevOutPhase[base + 1] + expPhase * (trueFreq + 1.0f);
+                        prevOutPhase[base + 1] = phase1;
+                        float cos1 = std::cos(phase1);
+                        float sin1 = std::sin(phase1);
+                        dest[2 * (base + 1)]     += mag * frac * cos1;
+                        dest[2 * (base + 1) + 1] += mag * frac * sin1;
+                    }
+                }
+            }
+
+            fft.performRealOnlyInverseTransform(dest.data());
+            window.multiplyWithWindowingTable(dest.data(), fftSize);
+
+            const float scale = 1.0f / (float)fftSize;
+            for (int i = 0; i < fftSize; ++i)
+                accum.addSample(0, pos + i, dest[i] * scale);
+
+            ranFrame = true;
+        };
+
+        int pos = 0;
+        for (; pos + fftSize <= numSamples; pos += hopSize)
+            processFrame(read + pos, fftSize, pos);
+
+        if (!ranFrame && numSamples > 0)
+            processFrame(read, numSamples, 0);
+
+        if (numSamples > 0 && accum.getNumSamples() != numSamples)
+            accum.setSize(1, numSamples, true, false, true);
+
+        float* write = buffer.getWritePointer(ch);
+        for (int i = 0; i < numSamples; ++i)
+            write[i] = accum.getSample(0, i);
+    }
+}

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/tests/test_main.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/tests/test_main.cpp
@@ -1,0 +1,226 @@
+#include <juce_core/juce_core.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_dsp/juce_dsp.h>
+#include <atomic>
+#include "../src/SamuRiserAudioProcessor.h"
+#include "../src/GranularEngine.h"
+#include "../src/SpectralEngine.h"
+#include "../src/HybridEngine.h"
+#include "../src/SammuMatcher.h"
+
+struct AnalysisTest : juce::UnitTest {
+    AnalysisTest() : juce::UnitTest("SourceFile Analysis", "Analysis") {}
+    void runTest() override {
+        beginTest("Analysis resets previous results");
+        SourceFile sf; sf.audio.setSize(1, 1024); sf.sampleRate = 48000.0;
+        for (int i = 0; i < sf.audio.getNumSamples(); ++i)
+            sf.audio.setSample(0, i, i % 2 ? 0.5f : -0.5f);
+        sf.analyze();
+        auto onsetCount = (int)sf.onsets.size(); auto hist = sf.pitchHist;
+        sf.analyze();
+        expectEquals((int)sf.onsets.size(), onsetCount);
+        expect(sf.pitchHist == hist);
+    }
+};
+
+struct GranularEngineTest : juce::UnitTest {
+    GranularEngineTest() : juce::UnitTest("Granular Engine", "DSP") {}
+    void runTest() override {
+        beginTest("snapToScale aligns to key");
+        GranularEngine ge; ge.setKey(9, true);
+        int note = ge.snapToScale(61);
+        expect(note == 60 || note == 62);
+
+        beginTest("process produces audio");
+        ge.setSampleRate(48000.0); ge.setSeed(42); ge.setDensity(1.0f); ge.setTexture(0.0f);
+        std::vector<std::shared_ptr<SourceFile>> pool;
+        auto src = std::make_shared<SourceFile>();
+        src->audio.setSize(1, 48000); src->sampleRate = 48000.0;
+        for (int i = 0; i < src->audio.getNumSamples(); ++i)
+            src->audio.setSample(0, i, std::sin(2.0 * juce::MathConstants<double>::pi * i / 100.0));
+        pool.push_back(src); ge.setPool(&pool);
+        juce::AudioBuffer<float> out; out.setSize(1, 512);
+        ge.process(out, 512, 120.0, 1);
+        bool nonZero = false;
+        for (int i = 0; i < out.getNumSamples(); ++i)
+            if (std::abs(out.getSample(0, i)) > 0.0f) { nonZero = true; break; }
+        expect(nonZero);
+    }
+};
+
+struct MatcherRendererTest : juce::UnitTest {
+    MatcherRendererTest() : juce::UnitTest("Matcher and Renderer", "DSP") {}
+    void runTest() override {
+        beginTest("Matcher builds schedule");
+        Segment a; a.length = 100; a.chroma = {1,0,0,0,0,0,0,0,0,0,0,0}; a.onsetDensity=0.5f; a.rms=0.5f; a.dominantPC=0;
+        Segment b; b.length = 100; b.chroma = {0,1,0,0,0,0,0,0,0,0,0,0}; b.onsetDensity=0.5f; b.rms=0.5f; b.dominantPC=1;
+        std::vector<std::vector<Segment>> pools = {{a},{b}};
+        MatchSettings ms; ms.barsPerSeg = 1; ms.scale = ScaleMask::makeMajor(0);
+        SegmentMatcher matcher; auto schedule = matcher.buildSchedule(pools, 2, ms);
+        expectEquals((int)schedule.size(), 2);
+
+        beginTest("Renderer outputs expected length");
+        juce::AudioBuffer<float> dummy; dummy.setSize(1, 48000);
+        Segment seg; seg.src = &dummy; seg.start = 0; seg.length = 48000; seg.srcSR = 48000.0;
+        SegmentGluedRenderer renderer; renderer.setSampleRate(48000.0);
+        std::vector<Segment> sched = {seg, seg};
+        juce::AudioBuffer<float> loop; std::atomic<bool> cancel(false);
+        renderer.render(sched, 120.0, 2, 1, loop, cancel);
+        expectEquals(loop.getNumSamples(), 192000);
+    }
+};
+
+struct EngineInteropTest : juce::UnitTest {
+    EngineInteropTest() : juce::UnitTest("Engine Interop", "DSP") {}
+    void runTest() override {
+        beginTest("Spectral and Hybrid engines produce audio");
+        SpectralEngine se; se.setSampleRate(48000.0); juce::AudioBuffer<float> buf; buf.setSize(1, 1024);
+        for (int i = 0; i < buf.getNumSamples(); ++i) buf.setSample(0, i, std::sin(0.01f*(float)i));
+        auto copy = buf; se.setPitchRatio(1.0f); se.process(buf, buf.getNumSamples(), 120.0, 1);
+        bool specNonZero=false; double err=0.0; for(int i=0;i<buf.getNumSamples();++i){float v=buf.getSample(0,i); specNonZero|=(v!=0.0f); float d=v-copy.getSample(0,i); err+=d*d;}
+        expect(specNonZero); expectLessThan(std::sqrt(err / buf.getNumSamples()), 0.01);
+
+        beginTest("Spectral engine processes short blocks");
+        juce::AudioBuffer<float> shortBuf; shortBuf.setSize(1, 256);
+        for (int i = 0; i < shortBuf.getNumSamples(); ++i)
+            shortBuf.setSample(0, i, std::sin(0.02f * (float)i));
+        se.process(shortBuf, shortBuf.getNumSamples(), 120.0, 1);
+        bool shortNonZero = false;
+        for (int i = 0; i < shortBuf.getNumSamples(); ++i)
+            if (shortBuf.getSample(0, i) != 0.0f) { shortNonZero = true; break; }
+        expect(shortNonZero);
+
+        HybridEngine he; he.setSampleRate(48000.0);
+        juce::AudioBuffer<float> hbuf; hbuf.setSize(1,512); for(int i=0;i<hbuf.getNumSamples();++i) hbuf.setSample(0,i,std::sin(0.02f*(float)i));
+        he.process(hbuf, hbuf.getNumSamples(), 120.0, 1);
+        bool hybNonZero=false; for(int i=0;i<hbuf.getNumSamples();++i) if(hbuf.getSample(0,i)!=0.0f){hybNonZero=true;break;}
+        expect(hybNonZero);
+    }
+};
+
+struct HybridMixTest : juce::UnitTest {
+    HybridMixTest() : juce::UnitTest("Hybrid mix", "DSP") {}
+    void runTest() override {
+        beginTest("Hybrid mix balances spectral and granular outputs");
+        HybridEngine he; he.setSampleRate(48000.0);
+
+        juce::AudioBuffer<float> input; input.setSize(1, 512);
+        for (int i = 0; i < input.getNumSamples(); ++i)
+            input.setSample(0, i, std::sin(0.01f * (float)i));
+
+        // reference spectral-only output
+        juce::AudioBuffer<float> spectralOnly = input;
+        SpectralEngine se; se.setSampleRate(48000.0); se.setPitchRatio(1.0f);
+        se.process(spectralOnly, spectralOnly.getNumSamples(), 120.0, 1);
+
+        he.setMix(0.0f);
+        juce::AudioBuffer<float> buf = input;
+        he.process(buf, buf.getNumSamples(), 120.0, 1);
+        for (int i = 0; i < buf.getNumSamples(); ++i)
+            expectWithinAbsoluteError(buf.getSample(0, i), spectralOnly.getSample(0, i), 1e-5f);
+
+        he.setMix(1.0f);
+        buf = input;
+        he.process(buf, buf.getNumSamples(), 120.0, 1);
+        for (int i = 0; i < buf.getNumSamples(); ++i)
+            expectWithinAbsoluteError(buf.getSample(0, i), input.getSample(0, i), 1e-5f);
+
+        he.setMix(0.5f);
+        buf = input;
+        he.process(buf, buf.getNumSamples(), 120.0, 1);
+        float specSample = spectralOnly.getSample(0, 0);
+        float drySample = input.getSample(0, 0);
+        expectWithinAbsoluteError(buf.getSample(0, 0), 0.5f * specSample + 0.5f * drySample, 1e-4f);
+    }
+};
+
+struct ResampleTest : juce::UnitTest {
+    ResampleTest() : juce::UnitTest("Processor resampling", "Processor") {}
+    void runTest() override {
+        beginTest("addFile resamples sources to host rate");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        juce::File tmp = juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("sr_test.wav");
+        juce::WavAudioFormat wf; {
+            std::unique_ptr<juce::FileOutputStream> os(tmp.createOutputStream());
+            auto writer = std::unique_ptr<juce::AudioFormatWriter>(wf.createWriterFor(os.release(), 48000, 1, 16, {}, 0));
+            juce::AudioBuffer<float> tb; tb.setSize(1,48000); tb.clear(); writer->writeFromAudioSampleBuffer(tb,0,tb.getNumSamples());
+        }
+        auto res = proc.addFile(tmp); tmp.deleteFile();
+        expect(res.wasOk());
+        expectEquals(proc.getPoolSize(), 1);
+    }
+};
+
+struct EditorTest : juce::UnitTest {
+    EditorTest() : juce::UnitTest("Editor", "UI") {}
+    void runTest() override {
+        beginTest("Processor creates editor");
+        SamuRiserAudioProcessor proc; auto editor = std::unique_ptr<juce::AudioProcessorEditor>(proc.createEditor());
+        expect(editor != nullptr);
+    }
+};
+
+struct PresetTest : juce::UnitTest {
+    PresetTest() : juce::UnitTest("Preset save/load", "Processor") {}
+    void runTest() override {
+        beginTest("Parameters round-trip through preset");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        auto* bpmParam = proc.getAPVTS().getRawParameterValue("bpm");
+        *const_cast<float*>(bpmParam) = 123.0f;
+        juce::File preset = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                                .getChildFile("preset.xml");
+        proc.savePreset(preset);
+        *const_cast<float*>(bpmParam) = 99.0f;
+        proc.loadPreset(preset);
+        preset.deleteFile();
+        expectWithinAbsoluteError(*bpmParam, 123.0f, 0.001f);
+    }
+};
+
+struct ExportErrorTest : juce::UnitTest {
+    ExportErrorTest() : juce::UnitTest("Export errors", "Processor") {}
+    void runTest() override {
+        beginTest("Non-WAV export fails");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        juce::File tmp = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                             .getChildFile("out.txt");
+        auto r = proc.exportLoopToFile(tmp);
+        expect(r.failed());
+    }
+};
+
+static AnalysisTest analysisTest;
+static GranularEngineTest granularTest;
+static MatcherRendererTest matcherRendererTest;
+static EngineInteropTest engineInteropTest;
+static HybridMixTest hybridMixTest;
+static ResampleTest resampleTest;
+static EditorTest editorTest;
+static PresetTest presetTest;
+static ExportErrorTest exportTest;
+struct RebuildCancelTest : juce::UnitTest {
+    RebuildCancelTest() : juce::UnitTest("Rebuild cancel", "Processor") {}
+    void runTest() override {
+        beginTest("Rebuild can be cancelled");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        juce::File tmp = juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("cancel.wav");
+        juce::WavAudioFormat wf; {
+            std::unique_ptr<juce::FileOutputStream> os(tmp.createOutputStream());
+            auto writer = std::unique_ptr<juce::AudioFormatWriter>(wf.createWriterFor(os.release(), 44100, 1, 16, {}, 0));
+            juce::AudioBuffer<float> tb; tb.setSize(1,44100); tb.clear(); writer->writeFromAudioSampleBuffer(tb,0,tb.getNumSamples());
+        }
+        proc.addFile(tmp); tmp.deleteFile();
+        proc.rebuildLoopAsync(120.0, 4, 2, true, 9);
+        proc.cancelRebuild();
+        expect(!proc.isRebuilding());
+    }
+};
+static RebuildCancelTest cancelTest;
+
+int main() {
+    juce::UnitTestRunner runner;
+    runner.runAllTests();
+    return runner.getFailures() > 0 ? 1 : 0;
+}
+


### PR DESCRIPTION
## Summary
- zero-pad short spectral engine blocks into a scratch frame so the FFT runs at least once and trim the overlap-add buffer back to the requested block length before writing
- reuse the accumulation buffer per channel while ensuring it is resized appropriately for processing and output
- add a regression unit test that exercises SpectralEngine::process with a sub-FFT block and verifies the result is not silent

## Testing
- cmake -B build -S . *(fails: missing X11 development headers required by JUCE)*

------
https://chatgpt.com/codex/tasks/task_b_68cd50b9062c8320bf8e71d7ae554709