### PR TITLE
Handle multichannel state in spectral engine

### DIFF
--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/CMakeLists.txt
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/CMakeLists.txt
@@ -1,0 +1,129 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(SamuRiser VERSION 0.1.0)
+
+## Use C++20 so that atomic specializations like std::atomic<std::shared_ptr<T>>
+## are defined.  The code relies on this feature, so building with C++17 would
+## trigger undefined behaviour on conforming toolchains.  Require the
+## standard explicitly so compilers don't silently downgrade.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED JUCE_DIR)
+    set(JUCE_DIR "${CMAKE_SOURCE_DIR}/deps/juce" CACHE PATH "Path to JUCE framework")
+endif()
+
+if(EXISTS "${JUCE_DIR}/CMakeLists.txt")
+    add_subdirectory(${JUCE_DIR} JUCE)
+else()
+    include(FetchContent)
+    FetchContent_Declare(
+        JUCE
+        GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+        GIT_TAG 8.0.0
+    )
+    FetchContent_MakeAvailable(JUCE)
+endif()
+
+juce_add_plugin(SamuRiser
+    COMPANY_NAME "Driftkind"
+    PLUGIN_MANUFACTURER_CODE Drft
+    PLUGIN_CODE SmRs
+    # Build VST3, AudioUnit and Standalone targets.  Including Standalone
+    # makes it easier to test the plug‑in outside a DAW.
+    FORMATS VST3 AU Standalone
+    IS_SYNTH TRUE
+    PRODUCT_NAME "SamuRiser"
+)
+
+target_sources(SamuRiser PRIVATE
+    src/SamuRiserAudioProcessor.cpp
+    src/SamuRiserAudioProcessor.h
+    src/GranularEngine.cpp
+    src/GranularEngine.h
+    src/SpectralEngine.cpp
+    src/SpectralEngine.h
+    src/HybridEngine.cpp
+    src/HybridEngine.h
+    src/SamuRiserAudioEditor.cpp
+    src/SamuRiserAudioEditor.h
+    src/SammuMatcher.cpp
+    src/SammuMatcher.h
+)
+
+target_compile_definitions(SamuRiser PRIVATE JUCE_WEB_BROWSER=0 JUCE_USE_CURL=0)
+
+if(MSVC)
+    target_compile_options(SamuRiser PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(SamuRiser PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+juce_generate_juce_header(SamuRiser)
+
+target_link_libraries(SamuRiser PRIVATE
+    juce::juce_audio_basics
+    juce::juce_audio_devices
+    juce::juce_audio_formats
+    juce::juce_audio_processors
+    juce::juce_audio_utils
+    juce::juce_gui_basics
+    juce::juce_dsp
+)
+
+enable_testing()
+add_executable(SamuRiserTests
+    tests/test_main.cpp
+    src/SamuRiserAudioProcessor.cpp
+    src/GranularEngine.cpp
+    src/SpectralEngine.cpp
+    src/HybridEngine.cpp
+    src/SammuMatcher.cpp
+)
+target_include_directories(SamuRiserTests PRIVATE src)
+target_link_libraries(SamuRiserTests PRIVATE
+    juce::juce_audio_basics
+    juce::juce_audio_formats
+    juce::juce_audio_processors
+    juce::juce_dsp
+)
+add_test(NAME SamuRiserTests COMMAND SamuRiserTests)
+
+add_executable(MultiChannelTests
+    tests/multichannel_tests.cpp
+    src/SpectralEngine.cpp
+    src/HybridEngine.cpp
+)
+target_include_directories(MultiChannelTests PRIVATE src)
+target_compile_definitions(MultiChannelTests PRIVATE JUCE_WEB_BROWSER=0 JUCE_USE_CURL=0)
+target_link_libraries(MultiChannelTests PRIVATE
+    juce::juce_audio_basics
+    juce::juce_dsp
+    juce::juce_gui_basics
+)
+add_test(NAME MultiChannelTests COMMAND MultiChannelTests)
+
+set(CPACK_PACKAGE_NAME "SamuRiser")
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+set(CPACK_GENERATOR "ZIP")
+include(CPack)
+
+option(SAMURISE_USE_RUBBERBAND "Use Rubber Band time-stretching" OFF)
+if(SAMURISE_USE_RUBBERBAND)
+    find_package(RubberBand REQUIRED)
+    target_link_libraries(SamuRiser PRIVATE RubberBand::rubberband)
+    target_link_libraries(SamuRiserTests PRIVATE RubberBand::rubberband)
+    target_compile_definitions(SamuRiser PRIVATE SAMURISE_USE_RUBBERBAND=1)
+    target_compile_definitions(SamuRiserTests PRIVATE SAMURISE_USE_RUBBERBAND=1)
+endif()
+
+if(APPLE AND DEFINED CODESIGN_IDENTITY)
+    add_custom_command(TARGET SamuRiser POST_BUILD
+        COMMAND codesign --force --sign "${CODESIGN_IDENTITY}" $<TARGET_FILE:SamuRiser>)
+endif()
+
+if(WIN32 AND DEFINED SIGNTOOL_EXE)
+    add_custom_command(TARGET SamuRiser POST_BUILD
+        COMMAND "${SIGNTOOL_EXE}" sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 $<TARGET_FILE:SamuRiser>)
+endif()
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SammuMatcher.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SammuMatcher.h
@@ -1,0 +1,316 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+#include <atomic>
+#ifdef SAMURISE_USE_RUBBERBAND
+#include <rubberband/RubberBandStretcher.h>
+#endif
+
+inline float hann(float x) { return 0.5f - 0.5f * std::cos(juce::MathConstants<float>::twoPi * x); }
+
+struct ScaleMask
+{
+    std::array<int, 12> mask{}; // 1 = allowed
+    static ScaleMask makeMajor(int root) { return makeFromPCs(root, {0,2,4,5,7,9,11}); }
+    static ScaleMask makeMinor(int root) { return makeFromPCs(root, {0,2,3,5,7,8,10}); }
+    static ScaleMask makeFromPCs(int root, std::initializer_list<int> pcs)
+    {
+        ScaleMask m; m.mask.fill(0);
+        for (auto pc : pcs)
+            m.mask[(root + pc + 120) % 12] = 1;
+        return m;
+    }
+};
+
+struct Segment
+{
+    const juce::AudioBuffer<float>* src = nullptr;
+    int start = 0;
+    int length = 0;
+    double srcSR = 44100.0;
+    std::array<float,12> chroma{};
+    float onsetDensity = 0.0f;
+    int   dominantPC = 0;
+    float rms = 0.0f;
+};
+
+class SegmentAnalyzer
+{
+public:
+    SegmentAnalyzer()
+    {
+        window.setSize(1, 1 << 11);
+        for (int i = 0; i < window.getNumSamples(); ++i)
+            window.setSample(0, i, hann((float)i / (float)(window.getNumSamples()-1)));
+    }
+
+    void sliceIntoSegments(const juce::AudioBuffer<float>& in,
+                           double fileSR, double bpm, int barsPerSeg,
+                           std::vector<Segment>& out)
+    {
+        const double secPerBeat = 60.0 / bpm;
+        const int segSamples = (int) std::round(barsPerSeg * 4 * secPerBeat * fileSR);
+        const int hop = segSamples;
+        for (int start = 0; start + segSamples <= in.getNumSamples(); start += hop)
+        {
+            Segment s;
+            s.src = &in; s.start = start; s.length = segSamples; s.srcSR = fileSR;
+            fingerprint(*s.src, s.start, s.length, fileSR, s.chroma, s.onsetDensity, s.dominantPC, s.rms);
+            out.push_back(std::move(s));
+        }
+    }
+
+private:
+    juce::AudioBuffer<float> window;
+
+    void fingerprint(const juce::AudioBuffer<float>& in, int start, int length, double sr,
+                     std::array<float,12>& chromaOut, float& onsetDensity,
+                     int& dominantPC, float& rmsOut)
+    {
+        juce::AudioBuffer<float> mono(1, length);
+        mono.clear();
+        for (int ch = 0; ch < in.getNumChannels(); ++ch)
+            mono.addFrom(0, 0, in, ch, start, length, 1.0f / juce::jmax(1, in.getNumChannels()));
+
+        const int fftSize = 1 << 11;
+        const int hopSize = fftSize / 4;
+        const int frames  = juce::jmax(1, (length - fftSize) / hopSize);
+
+        std::array<double,12> chromaSum{}; chromaSum.fill(0.0);
+        double rmsAccum = 0.0;
+        int onsetCount = 0; float prevEnergy = 0.0f;
+
+        juce::AudioBuffer<float> frame(1, fftSize);
+        juce::dsp::FFT fft(11);
+        juce::dsp::WindowingFunction<float> wfunc(fftSize, juce::dsp::WindowingFunction<float>::hann, true);
+
+        for (int f = 0; f < frames; ++f)
+        {
+            const int pos = f * hopSize;
+            frame.clear();
+            frame.copyFrom(0, 0, mono, 0, pos, fftSize);
+            wfunc.multiplyWithWindowingTable(frame.getWritePointer(0), fftSize);
+            fft.performRealOnlyForwardTransform(frame.getWritePointer(0));
+            auto* reim = frame.getWritePointer(0);
+            for (int k = 0; k < fftSize/2; ++k)
+            {
+                const float re = reim[2*k];
+                const float im = reim[2*k+1];
+                const float m  = std::sqrt(re*re + im*im) + 1e-9f;
+                const float freq = (float)k * (float)sr / (float)fftSize;
+                if (freq < 40.0f || freq > 8000.0f) continue;
+                const float midi = 69.0f + 12.0f * std::log2(freq / 440.0f);
+                const int pc = ((int)std::round(midi) % 12 + 12) % 12;
+                chromaSum[pc] += m;
+            }
+
+            float energy = 0.0f;
+            auto* d = frame.getReadPointer(0);
+            for (int i = 0; i < fftSize; ++i) energy += d[i]*d[i];
+            if (f > 0 && energy > prevEnergy * 1.35f) ++onsetCount;
+            prevEnergy = energy;
+            rmsAccum += std::sqrt(energy / (float)fftSize);
+        }
+
+        double total = 0.0; for (auto v : chromaSum) total += v;
+        for (int i = 0; i < 12; ++i)
+            chromaOut[i] = total > 0.0 ? (float)(chromaSum[i] / total) : (1.0f/12.0f);
+
+        dominantPC = 0; float best = chromaOut[0];
+        for (int i = 1; i < 12; ++i)
+            if (chromaOut[i] > best) { best = chromaOut[i]; dominantPC = i; }
+
+        onsetDensity = juce::jlimit(0.0f, 1.0f, (float)onsetCount / (float)juce::jmax(1, frames));
+        rmsOut = (float)(rmsAccum / (double)juce::jmax(1, frames));
+    }
+};
+
+struct MatchSettings
+{
+    float chromaWeight  = 0.8f;
+    float onsetWeight   = 0.2f;
+    float minSimilarity = 0.65f;
+    int   barsPerSeg    = 2;
+    ScaleMask scale     = ScaleMask::makeMinor(9);
+};
+
+inline float cosine12(const std::array<float,12>& a, const std::array<float,12>& b)
+{
+    double dot=0, na=0, nb=0; for (int i=0;i<12;++i){ dot+=a[i]*b[i]; na+=a[i]*a[i]; nb+=b[i]*b[i]; }
+    return (float)(dot / (std::sqrt(na*nb)+1e-9));
+}
+
+class SegmentMatcher
+{
+public:
+    std::vector<Segment> buildSchedule(const std::vector<std::vector<Segment>>& pools,
+                                       int totalBars, const MatchSettings& ms)
+    {
+        std::vector<Segment> schedule;
+        if (pools.empty()) return schedule;
+
+        Segment seed = pickSeed(pools, ms);
+        schedule.push_back(seed);
+
+        const int segBars = ms.barsPerSeg;
+        const int needSegs = juce::jmax(1, totalBars / segBars) - 1;
+
+        Segment cur = seed;
+        for (int i = 0; i < needSegs; ++i)
+        {
+            Segment best; float bestScore = -1.0f; bool found=false;
+            for (const auto& pool : pools)
+                for (const auto& cand : pool)
+                {
+                    if (cand.src == cur.src && std::abs(cand.start - cur.start) < cand.length) continue;
+                    float sim = similarity(cur, cand, ms);
+                    if (sim > ms.minSimilarity && sim > bestScore)
+                    {
+                        bestScore = sim; best = cand; found = true;
+                    }
+                }
+            schedule.push_back(found ? best : seed);
+            cur = schedule.back();
+        }
+        return schedule;
+    }
+
+private:
+    static bool pcAllowed(int pc, const ScaleMask& m) { return m.mask[(pc+120)%12] != 0; }
+
+    Segment pickSeed(const std::vector<std::vector<Segment>>& pools, const MatchSettings& ms)
+    {
+        Segment best; float score=-1e9f;
+        for (const auto& pool : pools)
+            for (const auto& s : pool)
+            {
+                float inKey = pcAllowed(s.dominantPC, ms.scale) ? 1.0f : 0.0f;
+                float sc = 0.7f * inKey + 0.3f * s.rms;
+                if (sc > score) { score = sc; best = s; }
+            }
+        return best;
+    }
+
+    float similarity(const Segment& a, const Segment& b, const MatchSettings& ms)
+    {
+        float c = cosine12(a.chroma, b.chroma);
+        float o = 1.0f - std::abs(a.onsetDensity - b.onsetDensity);
+        return ms.chromaWeight * c + ms.onsetWeight * o;
+    }
+};
+
+class SegmentGluedRenderer
+{
+public:
+    void setSampleRate(double sampleRate) { sr = sampleRate; }
+
+    void render(const std::vector<Segment>& schedule, double bpm, int totalBars,
+                int barsPerSeg, juce::AudioBuffer<float>& out, std::atomic<bool>& cancelFlag)
+    {
+        const int tgtLen = barsToSamples(totalBars, bpm);
+        out.setSize(2, tgtLen, false, true, true);
+        out.clear();
+
+        const int segLenTgt = barsToSamples(barsPerSeg, bpm);
+        const int xfade = (int) (0.02 * sr);
+
+        juce::AudioBuffer<float> tmp(2, segLenTgt + xfade * 2);
+
+        int cursor = 0;
+        for (size_t i = 0; i < schedule.size(); ++i)
+        {
+            if (cancelFlag.load()) return;
+            renderStretchedSegment(schedule[i], segLenTgt + (i==0?xfade:2*xfade), tmp);
+            const int writeStart = juce::jmax(0, cursor - xfade);
+            const int readStart  = (i==0?0:xfade);
+            const int writeLen   = juce::jmin(out.getNumSamples() - writeStart, tmp.getNumSamples() - readStart);
+
+            for (int n = 0; n < writeLen; ++n)
+            {
+                float w = 1.0f;
+                const int pos = n + writeStart - cursor + xfade;
+                if (pos < xfade) w = (float)pos / (float)xfade;
+                else if (pos > (segLenTgt + xfade)) w = 1.0f - (float)(pos - (segLenTgt + xfade)) / (float)xfade;
+
+                for (int ch = 0; ch < out.getNumChannels(); ++ch)
+                {
+                    float a = out.getSample(ch, writeStart + n);
+                    float b = tmp.getSample(juce::jmin(ch, tmp.getNumChannels()-1), readStart + n);
+                    out.setSample(ch, writeStart + n, a * (1.0f - w) + b * w);
+                }
+            }
+
+            cursor += segLenTgt;
+            if (cursor >= out.getNumSamples() || cancelFlag.load()) break;
+        }
+    }
+
+private:
+    double sr = 48000.0;
+
+    int barsToSamples(int bars, double bpm) const
+    {
+        const double sec = bars * 4.0 * 60.0 / bpm;
+        return (int) std::round(sec * sr);
+    }
+
+    void renderStretchedSegment(const Segment& s, int targetLen, juce::AudioBuffer<float>& dst)
+    {
+#ifdef SAMURISE_USE_RUBBERBAND
+        RubberBand::RubberBandStretcher stretcher(sr, 1,
+            RubberBand::RubberBandStretcher::OptionProcessRealTime);
+        stretcher.setTimeRatio((double)targetLen / (double)s.length);
+        juce::AudioBuffer<float> mono(1, s.length);
+        for (int ch = 0; ch < s.src->getNumChannels(); ++ch)
+            mono.addFrom(0, 0, *s.src, ch, s.start, s.length, 1.0f / juce::jmax(1, s.src->getNumChannels()));
+        stretcher.process(mono.getArrayOfReadPointers(), s.length, false);
+        juce::AudioBuffer<float> outBuf(1, targetLen);
+        stretcher.retrieve(outBuf.getArrayOfWritePointers(), targetLen);
+        dst.makeCopyOf(outBuf, true);
+        dst.setSize(2, targetLen, true, true, true);
+        dst.copyFrom(1, 0, dst, 0, 0, targetLen); // duplicate mono to stereo
+#else
+        const int grain = (int)(0.08 * sr);
+        const int hopIn = grain / 2;
+        const int hopOut = grain / 3;
+        const float rate = (float) s.length / (float) targetLen;
+
+        dst.setSize(2, targetLen);
+        dst.clear();
+
+        juce::AudioBuffer<float> mono(1, s.length);
+        mono.clear();
+        for (int ch = 0; ch < s.src->getNumChannels(); ++ch)
+            mono.addFrom(0, 0, *s.src, ch, s.start, s.length, 1.0f / juce::jmax(1, s.src->getNumChannels()));
+
+        int srcPos = 0, dstPos = 0;
+        juce::AudioBuffer<float> g(1, grain);
+        while (dstPos + grain < dst.getNumSamples() && srcPos + grain < mono.getNumSamples())
+        {
+            for (int i = 0; i < grain; ++i)
+            {
+                const float x = (srcPos + (int)(i * rate));
+                const int   i0 = juce::jlimit(0, mono.getNumSamples()-2, (int)x);
+                const float t  = x - (float)i0;
+                const float s0 = mono.getSample(0, i0);
+                const float s1 = mono.getSample(0, i0+1);
+                g.setSample(0, i, s0 + (s1 - s0) * t);
+            }
+            for (int i = 0; i < grain; ++i)
+            {
+                const float w = hann((float)i / (float)(grain-1));
+                const float v = g.getSample(0, i) * w;
+                for (int ch = 0; ch < dst.getNumChannels(); ++ch)
+                {
+                    const int p = dstPos + i;
+                    if (p < dst.getNumSamples())
+                        dst.addSample(ch, p, v * 0.7f);
+                }
+            }
+            srcPos += hopIn;
+            dstPos += hopOut;
+        }
+#endif
+    }
+};
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.cpp
@@ -1,0 +1,133 @@
+#include "SpectralEngine.h"
+
+void SpectralEngine::setSampleRate(double sr)
+{
+    sampleRate = sr;
+#ifdef SAMURISE_USE_RUBBERBAND
+    stretcher.reset(new RubberBand::RubberBandStretcher(
+        sr, 1, RubberBand::RubberBandStretcher::OptionProcessRealTime |
+            RubberBand::RubberBandStretcher::OptionPitchHighConsistency));
+#endif
+}
+
+//==============================================================================
+void SpectralEngine::process(juce::AudioBuffer<float>& buffer, int numSamples,
+                             double, int)
+{
+#ifdef SAMURISE_USE_RUBBERBAND
+    if (stretcher)
+    {
+        stretcher->setPitchScale(pitchRatio);
+        float* chans[2] = {
+            buffer.getWritePointer(0),
+            buffer.getNumChannels() > 1 ? buffer.getWritePointer(1) : buffer.getWritePointer(0)
+        };
+        stretcher->process(chans, (size_t)numSamples, false);
+        stretcher->retrieve(chans, (size_t)numSamples);
+        return;
+    }
+#endif
+
+    const int fftSize = fft.getSize();
+    const int hopSize = fftSize / 4; // 75% overlap for smoother OLA
+
+    if ((int)fftBuffer.size() < 2 * fftSize)
+        fftBuffer.resize(2 * fftSize, 0.0f);
+    if ((int)dest.size() < 2 * fftSize)
+        dest.resize(2 * fftSize, 0.0f);
+    if (accum.getNumChannels() < buffer.getNumChannels() ||
+        accum.getNumSamples() < numSamples + fftSize)
+        accum.setSize(buffer.getNumChannels(), numSamples + fftSize, false, false, true);
+    accum.clear();
+
+    const int bins = fftSize / 2;
+    if ((int)prevInPhase.size() < buffer.getNumChannels())
+    {
+        prevInPhase.resize(buffer.getNumChannels());
+        prevOutPhase.resize(buffer.getNumChannels());
+        prevMag.resize(buffer.getNumChannels());
+    }
+
+    const float freqPerBin = (float)sampleRate / (float)fftSize;
+    const float expPhase = juce::MathConstants<float>::twoPi * hopSize / (float)fftSize;
+
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+    {
+        auto& inPhase = prevInPhase[ch];
+        auto& outPhase = prevOutPhase[ch];
+        auto& magHistory = prevMag[ch];
+        if ((int)inPhase.size() < bins + 1)
+        {
+            inPhase.assign(bins + 1, 0.0f);
+            outPhase.assign(bins + 1, 0.0f);
+            magHistory.assign(bins + 1, 0.0f);
+        }
+
+        accum.clear(ch, 0, accum.getNumSamples());
+
+        const float* read = buffer.getReadPointer(ch);
+        for (int pos = 0; pos + fftSize <= numSamples; pos += hopSize)
+        {
+            std::fill(fftBuffer.begin(), fftBuffer.end(), 0.0f);
+            std::memcpy(fftBuffer.data(), read + pos, fftSize * sizeof(float));
+
+            window.multiplyWithWindowingTable(fftBuffer.data(), fftSize);
+            fft.performRealOnlyForwardTransform(fftBuffer.data());
+
+            std::fill(dest.begin(), dest.end(), 0.0f);
+            for (int i = 0; i < bins; ++i)
+            {
+                float freq = i * freqPerBin;
+                if (freq > cutoff) continue;
+
+                float re = fftBuffer[2 * i];
+                float im = fftBuffer[2 * i + 1];
+                float m = std::sqrt(re * re + im * im);
+                float phase = std::atan2(im, re);
+
+                magHistory[i] = 0.7f * magHistory[i] + 0.3f * m;
+
+                float delta = phase - inPhase[i];
+                inPhase[i] = phase;
+                delta -= expPhase * i;
+                delta = std::fmod(delta + juce::MathConstants<float>::pi,
+                                  juce::MathConstants<float>::twoPi) -
+                        juce::MathConstants<float>::pi;
+                float trueFreq = (i + delta / expPhase) * pitchRatio;
+                int base = (int)trueFreq;
+                float frac = trueFreq - (float)base;
+                if (base < bins)
+                {
+                    float mag = magHistory[i];
+                    float phase0 = outPhase[base] + expPhase * trueFreq;
+                    outPhase[base] = phase0;
+                    float cos0 = std::cos(phase0);
+                    float sin0 = std::sin(phase0);
+                    dest[2 * base] += mag * (1.0f - frac) * cos0;
+                    dest[2 * base + 1] += mag * (1.0f - frac) * sin0;
+
+                    if (base + 1 < bins)
+                    {
+                        float phase1 = outPhase[base + 1] + expPhase * (trueFreq + 1.0f);
+                        outPhase[base + 1] = phase1;
+                        float cos1 = std::cos(phase1);
+                        float sin1 = std::sin(phase1);
+                        dest[2 * (base + 1)] += mag * frac * cos1;
+                        dest[2 * (base + 1) + 1] += mag * frac * sin1;
+                    }
+                }
+            }
+
+            fft.performRealOnlyInverseTransform(dest.data());
+            window.multiplyWithWindowingTable(dest.data(), fftSize);
+
+            const float scale = 1.0f / (float)fftSize;
+            for (int i = 0; i < fftSize; ++i)
+                accum.addSample(ch, pos + i, dest[i] * scale);
+        }
+
+        float* write = buffer.getWritePointer(ch);
+        for (int i = 0; i < numSamples; ++i)
+            write[i] = accum.getSample(ch, i);
+    }
+}

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#ifdef SAMURISE_USE_RUBBERBAND
+ #include <rubberband/RubberBandStretcher.h>
+#endif
+
+class SpectralEngine
+{
+public:
+    void setSampleRate(double sr);
+    void setCutoff(float c) { cutoff = c; }
+    void setPitchRatio(float r) { pitchRatio = r; }
+
+    // Apply a simple FFT-based low-pass filter or optional Rubber Band pitch shift.
+    // This remains a lightweight placeholder for a true spectral resynthesis engine
+    // and exists to provide a distinct processing path from the granular engine.
+    void process(juce::AudioBuffer<float>& buffer, int numSamples, double, int);
+
+private:
+    double sampleRate = 44100.0;
+    juce::dsp::FFT fft{10};                                   // 1024-point FFT
+    juce::dsp::WindowingFunction<float> window{ (size_t)1024,
+        juce::dsp::WindowingFunction<float>::hann };
+    std::vector<float> fftBuffer;                             // real/imag pairs
+    std::vector<std::vector<float>> prevInPhase;              // per-channel phase vocoder state
+    std::vector<std::vector<float>> prevOutPhase;             // per-channel phase vocoder state
+    std::vector<std::vector<float>> prevMag;                  // per-channel magnitude envelope
+    juce::AudioBuffer<float> accum;                           // reuse accumulation buffer
+    std::vector<float> dest;                                  // reused FFT output
+#ifdef SAMURISE_USE_RUBBERBAND
+    std::unique_ptr<RubberBand::RubberBandStretcher> stretcher;
+#endif
+    float cutoff = 5000.0f;                                   // Hz
+    float pitchRatio = 1.0f;
+};

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/tests/multichannel_tests.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/tests/multichannel_tests.cpp
@@ -1,0 +1,105 @@
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+#include "SpectralEngine.h"
+#include "HybridEngine.h"
+
+namespace
+{
+float rmsDiff(const float* a, const float* b, int numSamples)
+{
+    double sum = 0.0;
+    for (int i = 0; i < numSamples; ++i)
+    {
+        double diff = static_cast<double>(a[i]) - static_cast<double>(b[i]);
+        sum += diff * diff;
+    }
+    return static_cast<float>(std::sqrt(sum / static_cast<double>(numSamples)));
+}
+}
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    constexpr double sampleRate = 48000.0;
+    constexpr int numSamples = 2048;
+    constexpr int numChannels = 2;
+
+    juce::AudioBuffer<float> input;
+    input.setSize(numChannels, numSamples);
+
+    for (int i = 0; i < numSamples; ++i)
+    {
+        input.setSample(0, i, std::sin(2.0 * juce::MathConstants<double>::pi * i / 64.0));
+        input.setSample(1, i, std::cos(2.0 * juce::MathConstants<double>::pi * i / 43.0));
+    }
+
+    auto spectralInput = input;
+    SpectralEngine spectralMulti;
+    spectralMulti.setSampleRate(sampleRate);
+    spectralMulti.setPitchRatio(1.0f);
+    spectralMulti.process(spectralInput, numSamples, 120.0, 1);
+
+    SpectralEngine spectralSingle0;
+    spectralSingle0.setSampleRate(sampleRate);
+    spectralSingle0.setPitchRatio(1.0f);
+    juce::AudioBuffer<float> single0;
+    single0.setSize(1, numSamples);
+    single0.copyFrom(0, 0, input, 0, 0, numSamples);
+    spectralSingle0.process(single0, numSamples, 120.0, 1);
+
+    SpectralEngine spectralSingle1;
+    spectralSingle1.setSampleRate(sampleRate);
+    spectralSingle1.setPitchRatio(1.0f);
+    juce::AudioBuffer<float> single1;
+    single1.setSize(1, numSamples);
+    single1.copyFrom(0, 0, input, 1, 0, numSamples);
+    spectralSingle1.process(single1, numSamples, 120.0, 1);
+
+    const float specDiff0 = rmsDiff(spectralInput.getReadPointer(0), single0.getReadPointer(0), numSamples);
+    const float specDiff1 = rmsDiff(spectralInput.getReadPointer(1), single1.getReadPointer(0), numSamples);
+
+    if (specDiff0 > 1.0e-3f || specDiff1 > 1.0e-3f)
+    {
+        std::cerr << "SpectralEngine multichannel mismatch: diff0=" << specDiff0
+                  << ", diff1=" << specDiff1 << std::endl;
+        std::_Exit(1);
+    }
+
+    auto hybridInput = input;
+    HybridEngine hybrid;
+    hybrid.setSampleRate(sampleRate);
+    hybrid.setPitchRatio(1.0f);
+    hybrid.setMix(0.35f);
+    hybrid.process(hybridInput, numSamples, 120.0, 1);
+
+    auto spectralForHybrid = input;
+    SpectralEngine spectralForMix;
+    spectralForMix.setSampleRate(sampleRate);
+    spectralForMix.setPitchRatio(1.0f);
+    spectralForMix.process(spectralForHybrid, numSamples, 120.0, 1);
+
+    juce::AudioBuffer<float> expected;
+    expected.makeCopyOf(spectralForHybrid);
+    expected.applyGain(1.0f - 0.35f);
+    for (int ch = 0; ch < numChannels; ++ch)
+        expected.addFrom(ch, 0, input, ch, 0, numSamples, 0.35f);
+
+    const float hybridDiff0 = rmsDiff(hybridInput.getReadPointer(0), expected.getReadPointer(0), numSamples);
+    const float hybridDiff1 = rmsDiff(hybridInput.getReadPointer(1), expected.getReadPointer(1), numSamples);
+
+    if (hybridDiff0 > 1.0e-3f || hybridDiff1 > 1.0e-3f)
+    {
+        std::cerr << "HybridEngine multichannel mismatch: diff0=" << hybridDiff0
+                  << ", diff1=" << hybridDiff1 << std::endl;
+        std::_Exit(1);
+    }
+
+    std::cout << "Multi-channel spectral and hybrid tests passed." << std::endl;
+    std::_Exit(0);
+}


### PR DESCRIPTION
## Summary
- resize the spectral engine accumulation buffer per channel and track phase history independently for each channel
- replace the global Jucer include in the matcher with the specific JUCE modules now required
- add a dedicated multichannel regression harness and wire it into CMake to guard against spectral and hybrid crosstalk

## Testing
- `cmake -S Driftkind-codex-implement-samuriseaudioprocessor-addfile -B Driftkind-codex-implement-samuriseaudioprocessor-addfile/build -DJUCE_BUILD_EXTRAS=OFF`
- `cmake --build Driftkind-codex-implement-samuriseaudioprocessor-addfile/build --target MultiChannelTests`
- `cd Driftkind-codex-implement-samuriseaudioprocessor-addfile/build && ctest -R MultiChannelTests --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_68cd50ba15c88320a7efa9a6886852cd