### PR TITLE
Handle short segments in fingerprint and add regression test

### DIFF
--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/.github/workflows/build.yml
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/.github/workflows/build.yml
@@ -1,0 +1,95 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    # Propagate signing and notarization secrets into the build environment.  These
+    # values are expected to be provided via the repository or organization
+    # settings in GitHub.  See README for details on how to obtain the
+    # appropriate credentials.
+    env:
+      # For macOS code signing (ID of your Developer ID Application certificate)
+      CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+      # Apple notarization credentials (Apple ID and app specific password)
+      AC_USERNAME: ${{ secrets.AC_USERNAME }}
+      AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+      # Optional team ID for notarization (if your Apple ID belongs to multiple teams)
+      AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}
+      # Path to signtool.exe on Windows for Authenticode signing
+      SIGNTOOL_EXE: ${{ secrets.SIGNTOOL_EXE }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JUCE
+        run: |
+          git clone --depth 1 https://github.com/juce-framework/JUCE.git deps/juce
+      - name: Configure
+        run: cmake -B build -S . -DJUCE_DIR=deps/juce
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Sign (macOS)
+        if: matrix.os == 'macos-latest' && env.CODESIGN_IDENTITY != ''
+        run: |
+          # Sign the VST3 and AudioUnit bundles.  Use --deep to ensure embedded
+          # frameworks and helper tools are signed.  Ignore errors if files
+          # aren't present (e.g. AU on Linux/Windows).
+          for plugin in build/*.vst3 build/*.component; do
+            if [ -e "$plugin" ]; then
+              codesign --deep --force --timestamp --sign "$CODESIGN_IDENTITY" "$plugin"
+            fi
+          done
+      - name: Sign (Windows)
+        if: matrix.os == 'windows-latest' && env.SIGNTOOL_EXE != ''
+        run: |
+          $env:SIGNTOOL_EXE sign /a build\*.vst3
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure
+      - name: Package
+        run: |
+          cd build
+          cpack -C Release
+      - name: Rename package
+        run: mv build/SamuRiser-*.zip build/SamuRiser-${{ matrix.os }}.zip
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: samuriser-${{ matrix.os }}
+          path: build/SamuRiser-${{ matrix.os }}.zip
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/SamuRiser-${{ matrix.os }}.zip
+
+      # Submit the macOS plug-in for notarization and staple the ticket.  Only run
+      # this step on release builds for macOS.  The package is submitted
+      # asynchronously and we wait for completion.
+      - name: Notarize and staple (macOS)
+        if: github.event_name == 'release' && matrix.os == 'macos-latest' && env.AC_USERNAME != '' && env.AC_PASSWORD != ''
+        run: |
+          # Submit the zipped plug‑in to Apple’s notarization service.  Use
+          # notarytool (newer) if available; fall back to altool otherwise.
+          ZIP="build/SamuRiser-${{ matrix.os }}.zip"
+          if xcrun notarytool --help > /dev/null 2>&1; then
+            xcrun notarytool submit "$ZIP" --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" ${AC_TEAM_ID:+--team-id "$AC_TEAM_ID"} --wait
+          else
+            xcrun altool --notarize-app -f "$ZIP" --primary-bundle-id "com.example.SamuRiser" -u "$AC_USERNAME" -p "$AC_PASSWORD" --output-format xml
+            # Wait for completion.  Notarization via altool may require polling; omitted for brevity.
+          fi
+          # After notarization completes, staple the ticket to both plugin bundles.
+          for plugin in build/*.vst3 build/*.component; do
+            if [ -e "$plugin" ]; then
+              xcrun stapler staple -v "$plugin"
+            fi
+          done

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/CMakeLists.txt
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/CMakeLists.txt
@@ -1,0 +1,115 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(SamuRiser VERSION 0.1.0)
+
+## Use C++20 so that atomic specializations like std::atomic<std::shared_ptr<T>>
+## are defined.  The code relies on this feature, so building with C++17 would
+## trigger undefined behaviour on conforming toolchains.  Require the
+## standard explicitly so compilers don't silently downgrade.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED JUCE_DIR)
+    set(JUCE_DIR "${CMAKE_SOURCE_DIR}/deps/juce" CACHE PATH "Path to JUCE framework")
+endif()
+
+if(EXISTS "${JUCE_DIR}/CMakeLists.txt")
+    add_subdirectory(${JUCE_DIR} JUCE)
+else()
+    include(FetchContent)
+    FetchContent_Declare(
+        JUCE
+        GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+        GIT_TAG 8.0.0
+    )
+    FetchContent_MakeAvailable(JUCE)
+endif()
+
+juce_add_plugin(SamuRiser
+    COMPANY_NAME "Driftkind"
+    PLUGIN_MANUFACTURER_CODE Drft
+    PLUGIN_CODE SmRs
+    # Build VST3, AudioUnit and Standalone targets.  Including Standalone
+    # makes it easier to test the plug‑in outside a DAW.
+    FORMATS VST3 AU Standalone
+    IS_SYNTH TRUE
+    PRODUCT_NAME "SamuRiser"
+)
+
+target_sources(SamuRiser PRIVATE
+    src/SamuRiserAudioProcessor.cpp
+    src/SamuRiserAudioProcessor.h
+    src/GranularEngine.cpp
+    src/GranularEngine.h
+    src/SpectralEngine.cpp
+    src/SpectralEngine.h
+    src/HybridEngine.cpp
+    src/HybridEngine.h
+    src/SamuRiserAudioEditor.cpp
+    src/SamuRiserAudioEditor.h
+    src/SammuMatcher.cpp
+    src/SammuMatcher.h
+)
+
+target_compile_definitions(SamuRiser PRIVATE JUCE_WEB_BROWSER=0 JUCE_USE_CURL=0)
+
+if(MSVC)
+    target_compile_options(SamuRiser PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(SamuRiser PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+juce_generate_juce_header(SamuRiser)
+
+target_link_libraries(SamuRiser PRIVATE
+    juce::juce_audio_basics
+    juce::juce_audio_devices
+    juce::juce_audio_formats
+    juce::juce_audio_processors
+    juce::juce_audio_utils
+    juce::juce_gui_basics
+    juce::juce_dsp
+)
+
+enable_testing()
+add_executable(SamuRiserTests
+    tests/test_main.cpp
+    src/SamuRiserAudioProcessor.cpp
+    src/GranularEngine.cpp
+    src/SpectralEngine.cpp
+    src/HybridEngine.cpp
+    src/SammuMatcher.cpp
+)
+target_include_directories(SamuRiserTests PRIVATE src)
+target_link_libraries(SamuRiserTests PRIVATE
+    juce::juce_audio_basics
+    juce::juce_audio_formats
+    juce::juce_audio_processors
+    juce::juce_dsp
+)
+add_test(NAME SamuRiserTests COMMAND SamuRiserTests)
+
+set(CPACK_PACKAGE_NAME "SamuRiser")
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+set(CPACK_GENERATOR "ZIP")
+include(CPack)
+
+option(SAMURISE_USE_RUBBERBAND "Use Rubber Band time-stretching" OFF)
+if(SAMURISE_USE_RUBBERBAND)
+    find_package(RubberBand REQUIRED)
+    target_link_libraries(SamuRiser PRIVATE RubberBand::rubberband)
+    target_link_libraries(SamuRiserTests PRIVATE RubberBand::rubberband)
+    target_compile_definitions(SamuRiser PRIVATE SAMURISE_USE_RUBBERBAND=1)
+    target_compile_definitions(SamuRiserTests PRIVATE SAMURISE_USE_RUBBERBAND=1)
+endif()
+
+if(APPLE AND DEFINED CODESIGN_IDENTITY)
+    add_custom_command(TARGET SamuRiser POST_BUILD
+        COMMAND codesign --force --sign "${CODESIGN_IDENTITY}" $<TARGET_FILE:SamuRiser>)
+endif()
+
+if(WIN32 AND DEFINED SIGNTOOL_EXE)
+    add_custom_command(TARGET SamuRiser POST_BUILD
+        COMMAND "${SIGNTOOL_EXE}" sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 $<TARGET_FILE:SamuRiser>)
+endif()
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/LICENSE
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Driftkind
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/README.md
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/README.md
@@ -1,0 +1,120 @@
+# Driftkind
+
+## Quick start (non‑technical users)
+
+This section gives a high‑level overview of how to get up and running with **SAMU‑RISER** without wading through development details.  If you just want to install the plug‑in, load it in your DAW and start making loops, follow these simple steps:
+
+1. **Download and run the installer**.  On macOS or Linux, open a terminal in the project folder and run:
+
+   ```sh
+   ./install.sh
+   ```
+
+   On Windows, double‑click `install.bat`.  These scripts will fetch JUCE (if necessary), configure and build the plug‑in with CMake, and copy the resulting `.vst3` (and `.component` on macOS) into your system’s plug‑ins folder.  The scripts may prompt you for your administrator password to install files into system directories.
+
+2. **Launch your DAW and insert the plug‑in**.  SAMU‑RISER appears as an instrument plug‑in (synth) rather than an effect.  Create a new instrument track and load it just as you would any other virtual instrument.  On macOS you’ll see both VST3 and Audio Unit versions; on Windows and Linux only VST3 is currently supported.
+
+3. **Import audio files**.  Drag and drop one or more of your own WAV/AIFF files onto the plug‑in window.  SAMU‑RISER analyses each file in the background and builds a “pool” of material from which it will spawn grains.  Imported files aren’t stored in presets, so you’ll need to re‑import them each time you start a new session.
+
+4. **Choose your loop parameters**.  Use the on‑screen controls to set the tempo (`BPM`), length (`Bars`), key and mode (Major/Minor), and adjust creative parameters like `Density`, `Texture`, `Hybrid Mix` (when using the Hybrid engine), `Humanize`, `Stereo Width` and whether the limiter is active.  The plug‑in automatically resynchronises to your DAW’s tempo when the transport is running.
+
+5. **Rebuild**.  Press the **Rebuild** button to generate a fresh loop from the analysed pool.  Changing the random seed will produce a different arrangement of grains.  Loops play back in real time so you can immediately audition the result.
+
+6. **Export and save presets**.  When you’ve found a loop you like, click **Export** to write a 16‑bit WAV file to disk.  Use **Save** to store parameter settings (except for the imported audio pool) into an XML preset, and **Load** to recall them later.  Because presets exclude audio data, you can share them with collaborators without transferring large files.
+
+That’s it!  For more detailed information on each parameter and the underlying architecture, read on.
+
+## One-click Install
+
+Run `./install.sh` on macOS or Linux, or `install.bat` on Windows. The script will:
+
+1. Ensure CMake and JUCE are available (cloning JUCE into `deps/juce` if missing).
+2. Configure and build the project via CMake.
+3. Copy the resulting plugin into your system's VST/AU directory.
+
+`./install.sh --help` provides more information.
+
+## Usage
+
+After building, load **SAMU-RISER** in your DAW. Drag audio files onto the plug-in window to add them to the pool. The main controls are:
+
+| Parameter | Description |
+|-----------|-------------|
+| BPM       | Target tempo for the generated loop |
+| Bars      | Length of the loop in bars |
+| Key Note  | Musical key root (C..B) |
+| Mode      | Major or Minor scale |
+| Density   | Number of simultaneous grains |
+| Texture   | Bias toward transient vs. sustained material |
+| Flavor    | Selects Granular, Spectral, or Hybrid engine |
+| Humanize  | Adds timing jitter to grain spawning |
+| Seed      | Random seed for deterministic generation |
+
+Press **Rebuild** to generate a new loop from the analysed pool. The rendered loop can play in real time or be exported.
+
+SAMU-RISER is built as a synth plug‑in, so most hosts list it among their instruments.
+
+Use **Export** to write the current N-bar loop to a WAV file. Presets can be saved or loaded via the **Save** and **Load** buttons, allowing loop configurations to be recalled across sessions.
+
+### Parameters
+
+The plug‑in exposes a number of parameters via the GUI and as DAW automatable controls:
+
+| Parameter  | Range/Type                    | Meaning |
+|-----------|-------------------------------|---------|
+| **BPM**   | 20–300 BPM                    | Target tempo for the generated loop.  If the host provides a tempo via its play head, the internal BPM will follow the host. |
+| **Bars**  | 1–128 integer                 | Length of the loop in bars.  A rebuild will produce a loop of this length. |
+| **Key Note** | C..B                        | Root note of the key used for scale‑snapping of grains. |
+| **Mode**  | Major / Minor                 | Scale mode used for pitch snapping. |
+| **Seed**  | 0–1 000 000 integer          | Random seed for deterministic loop generation.  Changing this seed regenerates a different arrangement. |
+| **Density** | 0–1 float                    | Controls how many grains are active simultaneously.  Lower values produce sparser textures; higher values produce denser clouds. |
+| **Texture** | 0–1 float                    | Biases grain spawning toward onsets (transients) vs. random locations.  0 focuses on transients; 1 focuses on sustained material. |
+| **Flavor** | Granular / Spectral / Hybrid | Selects which engine is used.  Granular uses grain synthesis, Spectral uses an FFT‑based resynthesis, and Hybrid blends the two. |
+| **Hybrid Mix** | 0–1 float                 | When the Hybrid flavor is selected, this controls the blend between the spectral (0) and granular (1) outputs. |
+| **Humanize** | On/Off                     | Adds random timing jitter to grain spawning for a looser feel. |
+| **Spectral Cutoff** | 200–20 000 Hz float | Low‑pass cutoff applied in the spectral engine. |
+| **Stereo Width** | 0–1 float              | Scales the stereo width of the output.  0 collapses to mono, 1 preserves the original side level. |
+| **Limiter** | On/Off                      | Enables a simple limiter to prevent clipping. |
+| **Limit Threshold** | –24…0 dB float      | Threshold for the limiter when enabled. |
+| **Bypass Bus** | On/Off                  | Bypasses the EQ/limiter “bus” processing stage. |
+
+> **Note:** Preset files save only parameter values.  The imported audio pool is not included, so after loading a preset you must re‑import your audio files.
+
+### Export & presets
+
+Use the **Export** button to write the current loop to a 16‑bit WAV file.  Support for 24‑bit and 32‑bit float export can be added by extending `exportLoopToFile()` (see `SamuRiserAudioProcessor::exportLoopToFile`).  **Save** and **Load** buttons serialize and restore the `AudioProcessorValueTreeState` to/from XML.
+
+### Development & tests
+
+This project uses JUCE 8 and requires CMake 3.15+ and a C++20 compiler.  To build manually:
+
+```sh
+cmake -B build -S . -DJUCE_DIR=/path/to/JUCE -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+
+The unit tests live under `tests/` and are compiled into a separate executable.  After building, run `ctest --test-dir build` to execute all tests.  A CI workflow in `.github/workflows/build.yml` builds and tests the project on Windows, macOS and Linux.
+
+### Rubber Band time‑stretching (optional)
+
+If you have the [Rubber Band Library](https://breakfastquay.com/rubberband/) installed, you can enable high‑quality time‑stretching and formant‑preserving pitch shifting by setting `-DSAMURISE_USE_RUBBERBAND=ON` when configuring CMake.  On systems without Rubber Band, the plug‑in will fall back to a simpler FFT‑based approach.
+
+### Standalone build
+
+In addition to VST3 and AudioUnit formats, the CMake configuration now builds a **Standalone** version.  You can run this binary directly to test the synth outside of a DAW.
+
+## Development
+
+The project uses JUCE 8 and CMake. Parameters are managed via `AudioProcessorValueTreeState`, with state saved/restored automatically. Unit tests live under `tests/` and can be run with `ctest` after building.
+
+Continuous integration runs on GitHub Actions for macOS, Windows and Linux. Each job invokes the one‑click installer, builds the plug‑in, runs the unit tests and packages a ZIP artifact.
+
+The spectral engine preallocates its working buffers to avoid per-block heap churn and can optionally use the [Rubber Band Library](https://breakfastquay.com/rubberband/) for formant-preserving pitch shifts when compiled with `SAMURISE_USE_RUBBERBAND`.
+
+The granular engine employs cubic interpolation with interpolated Hann envelopes to reduce aliasing and high-frequency roll-off when grains are pitched far from their original register.
+
+Package signed binaries with `cpack` after setting `CODESIGN_IDENTITY` (macOS) or `SIGNTOOL_EXE` (Windows) in the environment. Pull requests should run `cmake -B build -S .` and `ctest --test-dir build` before submission.
+
+## License
+
+This project is released under the [MIT License](LICENSE).

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/install.bat
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/install.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy Bypass -File "%~dp0scripts\install.ps1" %*

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/install.sh
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Entry point; dispatches to platform-specific installer
+if [[ "$1" == "--help" ]]; then
+  echo "Usage: $0"
+  echo "Calls platform-specific install script."
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win"* ]]; then
+  powershell -ExecutionPolicy Bypass -File "$SCRIPT_DIR/scripts/install.ps1" "$@"
+else
+  bash "$SCRIPT_DIR/scripts/install.sh" "$@"
+fi

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/scripts/install.ps1
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/scripts/install.ps1
@@ -1,0 +1,43 @@
+param()
+# One-click build and install script for Windows
+
+if ($args -contains '--help') {
+    Write-Host "Usage: install.ps1"
+    Write-Host "Builds the plugin using CMake and installs it to the user's VST3 folder."
+    exit 0
+}
+
+$Root = Resolve-Path (Join-Path $PSScriptRoot '..')
+$JuceDir = Join-Path $Root 'deps/juce'
+
+if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
+    Write-Error 'cmake is required'
+    exit 1
+}
+
+if (-not (Get-Command cl -ErrorAction SilentlyContinue)) {
+    Write-Error 'Visual Studio Build Tools (cl) are required'
+    exit 1
+}
+
+if (-not (Test-Path $JuceDir)) {
+    Write-Host "JUCE not found, cloning to $JuceDir"
+    New-Item -ItemType Directory -Force -Path (Join-Path $Root 'deps') | Out-Null
+    git clone --depth 1 https://github.com/juce-framework/JUCE.git $JuceDir | Out-Null
+}
+
+$buildDir = Join-Path $Root 'build'
+New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
+cmake -B $buildDir -S $Root -DJUCE_DIR=$JuceDir
+cmake --build $buildDir --config Release
+cpack --config "$buildDir/CPackConfig.cmake" | Out-Null
+
+$plugin = Get-ChildItem $buildDir -Filter *.vst3 -Recurse | Select-Object -First 1
+if ($plugin) {
+    $dest = Join-Path $Env:COMMONPROGRAMFILES 'VST3'
+    New-Item -ItemType Directory -Force -Path $dest | Out-Null
+    Copy-Item $plugin.FullName $dest -Recurse -Force
+    Write-Host "Installed $($plugin.Name) to $dest"
+} else {
+    Write-Warning 'Plugin artifact not found after build'
+}

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/scripts/install.sh
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/scripts/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+
+# One-click build and install script for macOS/Linux
+if [[ "$1" == "--help" ]]; then
+  echo "Usage: $0"
+  echo "Builds the plugin using CMake and installs it to the user's plug-in directory."
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JUCE_DIR="$ROOT_DIR/deps/juce"
+
+command -v cmake >/dev/null 2>&1 || { echo "cmake is required" >&2; exit 1; }
+
+if [ ! -d "$JUCE_DIR" ]; then
+  echo "JUCE not found, cloning to $JUCE_DIR"
+  mkdir -p "$ROOT_DIR/deps"
+  git clone --depth 1 https://github.com/juce-framework/JUCE.git "$JUCE_DIR"
+fi
+
+mkdir -p "$ROOT_DIR/build"
+# Always build Release when using single‑configuration generators (e.g. Ninja/Unix Makefiles).
+cmake -B "$ROOT_DIR/build" -S "$ROOT_DIR" -DJUCE_DIR="$JUCE_DIR" -DCMAKE_BUILD_TYPE=Release
+cmake --build "$ROOT_DIR/build" --config Release
+cpack --config "$ROOT_DIR/build/CPackConfig.cmake" >/dev/null 2>&1 || true
+
+VST3_PLUGIN=$(find "$ROOT_DIR/build" -maxdepth 3 -name '*.vst3' -type d 2>/dev/null | head -n 1)
+AU_PLUGIN=$(find "$ROOT_DIR/build" -maxdepth 3 -name '*.component' -type d 2>/dev/null | head -n 1)
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  VST3_DIR="$HOME/Library/Audio/Plug-Ins/VST3"
+  AU_DIR="$HOME/Library/Audio/Plug-Ins/Components"
+  mkdir -p "$VST3_DIR" "$AU_DIR"
+  if [ -n "$VST3_PLUGIN" ]; then
+    cp -R "$VST3_PLUGIN" "$VST3_DIR/"
+    echo "Installed $(basename "$VST3_PLUGIN") to $VST3_DIR"
+  fi
+  if [ -n "$AU_PLUGIN" ]; then
+    cp -R "$AU_PLUGIN" "$AU_DIR/"
+    echo "Installed $(basename "$AU_PLUGIN") to $AU_DIR"
+  fi
+else
+  if [ -n "$VST3_PLUGIN" ]; then
+    VST3_DIR="$HOME/.vst3"
+    mkdir -p "$VST3_DIR"
+    cp -R "$VST3_PLUGIN" "$VST3_DIR/"
+    echo "Installed $(basename "$VST3_PLUGIN") to $VST3_DIR"
+  fi
+fi
+
+if [ -z "$VST3_PLUGIN" ] && [ -z "$AU_PLUGIN" ]; then
+  echo "Plugin artifact not found after build"
+fi

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/GranularEngine.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/GranularEngine.cpp
@@ -1,0 +1,245 @@
+#include "GranularEngine.h"
+#include "SamuRiserAudioProcessor.h" // for SourceFile
+
+#include <algorithm>
+#include <numeric>
+
+//==============================================================================
+// Returns the nearest MIDI note that belongs to the current key/scale.
+int GranularEngine::snapToScale(int midiNote) const
+{
+    // Allowed pitch classes for major and minor scales
+    static constexpr int majorScale[7] = {0, 2, 4, 5, 7, 9, 11};
+    static constexpr int minorScale[7] = {0, 2, 3, 5, 7, 8, 10};
+
+    const auto& scale = isMinor ? minorScale : majorScale;
+
+    // Build a lookup of allowed pitch classes shifted by keyRoot
+    std::array<bool, 12> allowed{};
+    allowed.fill(false);
+    for (int step : scale)
+        allowed[(step + keyRoot + 12) % 12] = true;
+
+    // Normalise the incoming note to a positive pitch class
+    const int baseNote = midiNote;
+    const int pc = ((midiNote % 12) + 12) % 12;
+
+    if (allowed[pc])
+        return baseNote; // already in scale
+
+    // Search outward for the nearest allowed pitch class
+    for (int offset = 1; offset <= 12; ++offset)
+    {
+        int upPC = (pc + offset) % 12;
+        if (allowed[upPC])
+            return baseNote + offset;
+
+        int downPC = (pc - offset + 12) % 12;
+        if (allowed[downPC])
+            return baseNote - offset;
+    }
+
+    return baseNote; // fallback, shouldn't reach here
+}
+
+//==============================================================================
+GranularEngine::GranularEngine()
+{
+    for (size_t i = 0; i < envTable.size(); ++i)
+        envTable[i] = 0.5f - 0.5f * std::cos(juce::MathConstants<float>::twoPi *
+                                             (float)i / (envTable.size() - 1));
+}
+
+float GranularEngine::getEnv(float phase) const
+{
+    const float pos = juce::jlimit(0.0f, 1.0f, phase) * (envTable.size() - 1);
+    const int idx = (int)pos;
+    const int next = juce::jmin(idx + 1, (int)envTable.size() - 1);
+    const float frac = pos - (float)idx;
+    return envTable[(size_t)idx] + frac * (envTable[(size_t)next] - envTable[(size_t)idx]);
+}
+
+//==============================================================================
+// Schedule new grains based on density, texture and a 16th-note tempo grid.
+void GranularEngine::spawnGrains(int samplesNeeded)
+{
+    auto p = pool; // atomic load
+    if (!p || p->empty())
+        return;
+
+    // Guard against invalid or extremely low BPM values which could otherwise
+    // produce huge grain intervals or divide-by-zero errors. 20 BPM is a
+    // sensible lower bound for musical material.
+    const double safeBpm = juce::jmax(20.0, currentBpm);
+
+    // Length of a 16th note in samples
+    const int grid = static_cast<int>(sampleRate * 60.0 / (safeBpm * 4.0));
+
+    samplesUntilNext -= samplesNeeded;
+
+    while (samplesUntilNext <= 0)
+    {
+        int jitter = 0;
+        if (humanize)
+        {
+            const int maxJit = (int)(0.02 * sampleRate); // +/-20ms
+            jitter = rng.nextInt(maxJit * 2) - maxJit;
+        }
+
+        samplesUntilNext += grid + jitter;
+
+        const float dens = density.getNextValue();
+        if (rng.nextFloat() > dens)
+            continue; // skip this slot based on density
+
+        // Find an inactive grain slot
+        Grain* g = nullptr;
+        for (auto& gr : grains)
+        {
+            if (!gr.active)
+            {
+                g = &gr;
+                break;
+            }
+        }
+
+        if (g == nullptr)
+            break; // no free grain slots
+
+        auto src = (*p)[rng.nextInt((int)p->size())];
+
+        int start = 0;
+        const float tex = texture.getNextValue();
+        if (!src->onsets.empty() && rng.nextFloat() < (1.0f - tex))
+            start = src->onsets[rng.nextInt((int)src->onsets.size())];
+        else
+            start = rng.nextInt(src->audio.getNumSamples());
+
+        const int maxLen = juce::jmin(2048, src->audio.getNumSamples() - start);
+        if (maxLen < 2)
+            continue;
+
+        // Determine dominant pitch class and snap to key. If the source has no
+        // detectable pitch content (empty histogram) we skip snapping so that
+        // noise or percussive material plays back unshifted.
+        int semitone = 0;
+        const int pitchSum = std::accumulate(src->pitchHist.begin(), src->pitchHist.end(), 0);
+        if (pitchSum > 0)
+        {
+            const auto it = std::max_element(src->pitchHist.begin(), src->pitchHist.end());
+            const int dominantPC = (int)std::distance(src->pitchHist.begin(), it);
+            const int baseNote = 60 + dominantPC;
+            const int snapped = snapToScale(baseNote);
+            semitone = snapped - baseNote;
+        }
+
+        g->src = src;
+        g->pos = static_cast<float>(start);
+        g->len = maxLen;
+        g->rate = pitchToRate(semitone);
+        g->amp = 1.0f;
+        g->envPhase = 0.0f;
+        g->envInc = 1.0f / static_cast<float>(maxLen);
+        g->active = true;
+    }
+}
+
+//==============================================================================
+void GranularEngine::renderGrains(juce::AudioBuffer<float>& out, int numSamples)
+{
+    const int outChans = out.getNumChannels();
+
+    int active = 0;
+    for (auto& g : grains)
+    {
+        if (!g.active || g.src == nullptr)
+            continue;
+        ++active;
+
+        const auto& srcBuf = g.src->audio;
+        const int srcChans = srcBuf.getNumChannels();
+        const int srcLen   = srcBuf.getNumSamples();
+
+        for (int i = 0; i < numSamples; ++i)
+        {
+            if (g.envPhase >= 1.0f)
+            {
+                g.active = false;
+                break;
+            }
+
+            const int idx = (int) g.pos;
+            if (idx < 1 || idx + 2 >= srcLen)
+            {
+                g.active = false;
+                break;
+            }
+
+            const float frac = g.pos - static_cast<float>(idx);
+            const float env  = getEnv(g.envPhase);
+
+            for (int ch = 0; ch < outChans; ++ch)
+            {
+                const float* src = srcBuf.getReadPointer(ch % srcChans);
+                const float y0 = src[idx - 1];
+                const float y1 = src[idx];
+                const float y2 = src[idx + 1];
+                const float y3 = src[idx + 2];
+                const float a0 = y3 - y2 - y0 + y1;
+                const float a1 = y0 - y1 - a0;
+                const float a2 = y2 - y0;
+                const float a3 = y1;
+                const float sample = ((a0 * frac + a1) * frac + a2) * frac + a3;
+                out.addSample(ch, i, sample * env * g.amp);
+            }
+
+            g.pos += g.rate;
+            g.envPhase += g.envInc;
+        }
+    }
+
+    activeCount.store(active, std::memory_order_relaxed);
+}
+
+//==============================================================================
+void GranularEngine::process(juce::AudioBuffer<float>& out, int numSamples, double bpm, int bars)
+{
+    out.clear();
+
+    currentBpm = bpm;
+    loopSamples = static_cast<int>(sampleRate * 60.0 / bpm * 4.0 * bars);
+
+    spawnGrains(numSamples);
+    renderGrains(out, numSamples);
+
+    playHead += numSamples;
+    if (loopSamples > 0)
+        playHead %= loopSamples;
+}
+
+//==============================================================================
+void GranularEngine::renderLoop(juce::AudioBuffer<float>& out, double bpm, int bars)
+{
+    const int total = static_cast<int>(sampleRate * 60.0 / bpm * 4.0 * bars);
+    out.setSize(2, total); // stereo buffer
+    out.clear();
+
+    // Reset state
+    for (auto& g : grains)
+        g.active = false;
+    samplesUntilNext = 0;
+    playHead = 0;
+
+    juce::AudioBuffer<float> temp(out.getNumChannels(), 512);
+    int rendered = 0;
+    while (rendered < total)
+    {
+        const int block = juce::jmin(512, total - rendered);
+        temp.setSize(out.getNumChannels(), block, false, false, true);
+        process(temp, block, bpm, bars);
+        for (int ch = 0; ch < out.getNumChannels(); ++ch)
+            out.addFrom(ch, rendered, temp, ch, 0, block);
+        rendered += block;
+    }
+}
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/GranularEngine.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/GranularEngine.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+#include <array>
+#include <vector>
+#include <memory>
+#include <cmath>
+
+struct SourceFile;
+struct Grain
+{
+    std::shared_ptr<const SourceFile> src; // reference-counted source audio
+    float pos = 0.0f;                      // current fractional position in samples
+    int   len = 0;                         // grain length in samples
+    float rate = 1.0f;                     // playback rate (pitch)
+    float amp = 1.0f;                      // linear amplitude
+    float envPhase = 0.0f;                 // 0..1 envelope phase
+    float envInc = 0.0f;                   // envelope increment per sample
+    bool  active = false;
+};
+
+class GranularEngine
+{
+public:
+    GranularEngine();
+
+    void setSampleRate(double sr) { sampleRate = sr; density.reset(sr, 0.05); texture.reset(sr, 0.05); }
+    void setPool(std::shared_ptr<const std::vector<std::shared_ptr<SourceFile>>> p) { pool = std::move(p); }
+    void setKey(int root, bool minor) { keyRoot = root; isMinor = minor; }
+    void setSeed(uint32_t s) { rng.setSeed(s); }
+    void setDensity(float d) { density.setTargetValue(juce::jlimit(0.0f, 1.0f, d)); }
+    void setTexture(float t) { texture.setTargetValue(juce::jlimit(0.0f, 1.0f, t)); }
+    void setHumanize(bool h) { humanize = h; }
+
+    // Map a MIDI note to the nearest allowed pitch in the current key.
+    int snapToScale(int midiNote) const;
+
+    void spawnGrains(int samplesNeeded);
+    void renderGrains(juce::AudioBuffer<float>& out, int numSamples);
+    void process(juce::AudioBuffer<float>& out, int numSamples, double bpm, int bars);
+    void renderLoop(juce::AudioBuffer<float>& out, double bpm, int bars);
+
+    // Current number of active grains for UI metering
+    int getActiveCount() const { return activeCount.load(); }
+
+private:
+    double sampleRate = 44100.0;                                  // processing sample rate
+    std::shared_ptr<const std::vector<std::shared_ptr<SourceFile>>> pool; // analysed file pool
+    int   keyRoot = 0;                                            // 0=C, 1=C# ... 11=B
+    bool  isMinor = false;                                       // major/minor flag
+    juce::dsp::SmoothedValue<float> density {0.5f};             // smoothed density
+    juce::dsp::SmoothedValue<float> texture {0.5f};             // smoothed texture
+    bool humanize = false;                                      // timing variance toggle
+    juce::Random rng { 0x1234abcd };                             // deterministic random
+    double currentBpm = 120.0;                                   // cached tempo
+    int samplesUntilNext = 0;                                     // samples until next spawn
+    int loopSamples = 0;                                          // total samples in loop
+    int playHead = 0;                                             // current playback position
+
+    static constexpr int maxGrains = 64;
+    std::array<Grain, maxGrains> grains;                         // active grains
+    std::array<float, 2048> envTable{};                          // precomputed Hann
+
+    std::atomic<int> activeCount {0};                             // active grain counter
+
+    float pitchToRate(int semitones) const { return std::pow(2.0f, semitones / 12.0f); }
+    float getEnv(float phase) const;
+};
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/HybridEngine.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/HybridEngine.cpp
@@ -1,0 +1,23 @@
+#include "HybridEngine.h"
+
+//==============================================================================
+void HybridEngine::process(juce::AudioBuffer<float>& buffer, int numSamples,
+                           double bpm, int bars)
+{
+    // Only resize the temporary buffer if the dimensions have changed.  JUCE will
+    // avoid reallocating if the size is the same, but checking first reduces
+    // overhead on the audio thread.
+    if (temp.getNumChannels() != buffer.getNumChannels() || temp.getNumSamples() != numSamples)
+        temp.setSize(buffer.getNumChannels(), numSamples, false, false, true);
+    temp.makeCopyOf(buffer);
+
+    spectral.process(buffer, numSamples, bpm, bars);
+
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+        for (int i = 0; i < numSamples; ++i)
+        {
+            float g = temp.getSample(ch, i);
+            float s = buffer.getSample(ch, i);
+            buffer.setSample(ch, i, s * (1.0f - mix) + g * mix);
+        }
+}

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/HybridEngine.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/HybridEngine.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+#include "SpectralEngine.h"
+
+class HybridEngine
+{
+public:
+    void setSampleRate(double sr) { sampleRate = sr; spectral.setSampleRate(sr); }
+    void setMix(float m) { mix = juce::jlimit(0.0f, 1.0f, m); }
+    void setPitchRatio(float r) { spectral.setPitchRatio(r); }
+
+    // Blend spectral and granular outputs for a simple "hybrid" flavour.
+    void process(juce::AudioBuffer<float>& buffer, int numSamples, double bpm, int bars);
+
+private:
+    double sampleRate = 44100.0;
+    SpectralEngine spectral;
+    juce::AudioBuffer<float> temp;
+    float mix = 0.5f;
+};

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SammuMatcher.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SammuMatcher.cpp
@@ -1,0 +1,3 @@
+#include "SammuMatcher.h"
+
+// Implementation is header-only; this file exists to satisfy build systems.

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SammuMatcher.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SammuMatcher.h
@@ -1,0 +1,325 @@
+#pragma once
+#include <JuceHeader.h>
+#include <atomic>
+#ifdef SAMURISE_USE_RUBBERBAND
+#include <rubberband/RubberBandStretcher.h>
+#endif
+
+inline float hann(float x) { return 0.5f - 0.5f * std::cos(juce::MathConstants<float>::twoPi * x); }
+
+struct ScaleMask
+{
+    std::array<int, 12> mask{}; // 1 = allowed
+    static ScaleMask makeMajor(int root) { return makeFromPCs(root, {0,2,4,5,7,9,11}); }
+    static ScaleMask makeMinor(int root) { return makeFromPCs(root, {0,2,3,5,7,8,10}); }
+    static ScaleMask makeFromPCs(int root, std::initializer_list<int> pcs)
+    {
+        ScaleMask m; m.mask.fill(0);
+        for (auto pc : pcs)
+            m.mask[(root + pc + 120) % 12] = 1;
+        return m;
+    }
+};
+
+struct Segment
+{
+    const juce::AudioBuffer<float>* src = nullptr;
+    int start = 0;
+    int length = 0;
+    double srcSR = 44100.0;
+    std::array<float,12> chroma{};
+    float onsetDensity = 0.0f;
+    int   dominantPC = 0;
+    float rms = 0.0f;
+};
+
+class SegmentAnalyzer
+{
+public:
+    SegmentAnalyzer()
+    {
+        window.setSize(1, 1 << 11);
+        for (int i = 0; i < window.getNumSamples(); ++i)
+            window.setSample(0, i, hann((float)i / (float)(window.getNumSamples()-1)));
+    }
+
+    void sliceIntoSegments(const juce::AudioBuffer<float>& in,
+                           double fileSR, double bpm, int barsPerSeg,
+                           std::vector<Segment>& out)
+    {
+        const double secPerBeat = 60.0 / bpm;
+        const int segSamples = (int) std::round(barsPerSeg * 4 * secPerBeat * fileSR);
+        const int hop = segSamples;
+        for (int start = 0; start + segSamples <= in.getNumSamples(); start += hop)
+        {
+            Segment s;
+            s.src = &in; s.start = start; s.length = segSamples; s.srcSR = fileSR;
+            fingerprint(*s.src, s.start, s.length, fileSR, s.chroma, s.onsetDensity, s.dominantPC, s.rms);
+            out.push_back(std::move(s));
+        }
+    }
+
+private:
+    juce::AudioBuffer<float> window;
+
+    void fingerprint(const juce::AudioBuffer<float>& in, int start, int length, double sr,
+                     std::array<float,12>& chromaOut, float& onsetDensity,
+                     int& dominantPC, float& rmsOut)
+    {
+        juce::AudioBuffer<float> mono(1, length);
+        mono.clear();
+        for (int ch = 0; ch < in.getNumChannels(); ++ch)
+            mono.addFrom(0, 0, in, ch, start, length, 1.0f / juce::jmax(1, in.getNumChannels()));
+
+        const int fftSize = 1 << 11;
+        const int hopSize = fftSize / 4;
+        const int frames  = juce::jmax(1, (juce::jmax(0, length - fftSize)) / hopSize);
+
+        std::array<double,12> chromaSum{}; chromaSum.fill(0.0);
+        double rmsAccum = 0.0;
+        int onsetCount = 0; float prevEnergy = 0.0f;
+        int processedFrames = 0;
+
+        juce::AudioBuffer<float> frame(1, fftSize);
+        juce::dsp::FFT fft(11);
+        juce::dsp::WindowingFunction<float> wfunc(fftSize, juce::dsp::WindowingFunction<float>::hann, true);
+
+        for (int f = 0; f < frames; ++f)
+        {
+            const int pos = f * hopSize;
+            frame.clear();
+            const int available = juce::jmax(0, mono.getNumSamples() - pos);
+            const int copyLen = juce::jmin(fftSize, available);
+            if (copyLen <= 0)
+                continue;
+
+            frame.copyFrom(0, 0, mono, 0, pos, copyLen);
+            if (copyLen < fftSize)
+                frame.clear(0, copyLen, fftSize - copyLen);
+            ++processedFrames;
+            wfunc.multiplyWithWindowingTable(frame.getWritePointer(0), fftSize);
+            fft.performRealOnlyForwardTransform(frame.getWritePointer(0));
+            auto* reim = frame.getWritePointer(0);
+            for (int k = 0; k < fftSize/2; ++k)
+            {
+                const float re = reim[2*k];
+                const float im = reim[2*k+1];
+                const float m  = std::sqrt(re*re + im*im) + 1e-9f;
+                const float freq = (float)k * (float)sr / (float)fftSize;
+                if (freq < 40.0f || freq > 8000.0f) continue;
+                const float midi = 69.0f + 12.0f * std::log2(freq / 440.0f);
+                const int pc = ((int)std::round(midi) % 12 + 12) % 12;
+                chromaSum[pc] += m;
+            }
+
+            float energy = 0.0f;
+            auto* d = frame.getReadPointer(0);
+            for (int i = 0; i < fftSize; ++i) energy += d[i]*d[i];
+            if (f > 0 && energy > prevEnergy * 1.35f) ++onsetCount;
+            prevEnergy = energy;
+            rmsAccum += std::sqrt(energy / (float)fftSize);
+        }
+
+        double total = 0.0; for (auto v : chromaSum) total += v;
+        for (int i = 0; i < 12; ++i)
+            chromaOut[i] = total > 0.0 ? (float)(chromaSum[i] / total) : (1.0f/12.0f);
+
+        dominantPC = 0; float best = chromaOut[0];
+        for (int i = 1; i < 12; ++i)
+            if (chromaOut[i] > best) { best = chromaOut[i]; dominantPC = i; }
+
+        const int normFrames = juce::jmax(1, processedFrames);
+        onsetDensity = juce::jlimit(0.0f, 1.0f, (float)onsetCount / (float)normFrames);
+        rmsOut = (float)(rmsAccum / (double)normFrames);
+    }
+};
+
+struct MatchSettings
+{
+    float chromaWeight  = 0.8f;
+    float onsetWeight   = 0.2f;
+    float minSimilarity = 0.65f;
+    int   barsPerSeg    = 2;
+    ScaleMask scale     = ScaleMask::makeMinor(9);
+};
+
+inline float cosine12(const std::array<float,12>& a, const std::array<float,12>& b)
+{
+    double dot=0, na=0, nb=0; for (int i=0;i<12;++i){ dot+=a[i]*b[i]; na+=a[i]*a[i]; nb+=b[i]*b[i]; }
+    return (float)(dot / (std::sqrt(na*nb)+1e-9));
+}
+
+class SegmentMatcher
+{
+public:
+    std::vector<Segment> buildSchedule(const std::vector<std::vector<Segment>>& pools,
+                                       int totalBars, const MatchSettings& ms)
+    {
+        std::vector<Segment> schedule;
+        if (pools.empty()) return schedule;
+
+        Segment seed = pickSeed(pools, ms);
+        schedule.push_back(seed);
+
+        const int segBars = ms.barsPerSeg;
+        const int needSegs = juce::jmax(1, totalBars / segBars) - 1;
+
+        Segment cur = seed;
+        for (int i = 0; i < needSegs; ++i)
+        {
+            Segment best; float bestScore = -1.0f; bool found=false;
+            for (const auto& pool : pools)
+                for (const auto& cand : pool)
+                {
+                    if (cand.src == cur.src && std::abs(cand.start - cur.start) < cand.length) continue;
+                    float sim = similarity(cur, cand, ms);
+                    if (sim > ms.minSimilarity && sim > bestScore)
+                    {
+                        bestScore = sim; best = cand; found = true;
+                    }
+                }
+            schedule.push_back(found ? best : seed);
+            cur = schedule.back();
+        }
+        return schedule;
+    }
+
+private:
+    static bool pcAllowed(int pc, const ScaleMask& m) { return m.mask[(pc+120)%12] != 0; }
+
+    Segment pickSeed(const std::vector<std::vector<Segment>>& pools, const MatchSettings& ms)
+    {
+        Segment best; float score=-1e9f;
+        for (const auto& pool : pools)
+            for (const auto& s : pool)
+            {
+                float inKey = pcAllowed(s.dominantPC, ms.scale) ? 1.0f : 0.0f;
+                float sc = 0.7f * inKey + 0.3f * s.rms;
+                if (sc > score) { score = sc; best = s; }
+            }
+        return best;
+    }
+
+    float similarity(const Segment& a, const Segment& b, const MatchSettings& ms)
+    {
+        float c = cosine12(a.chroma, b.chroma);
+        float o = 1.0f - std::abs(a.onsetDensity - b.onsetDensity);
+        return ms.chromaWeight * c + ms.onsetWeight * o;
+    }
+};
+
+class SegmentGluedRenderer
+{
+public:
+    void setSampleRate(double sampleRate) { sr = sampleRate; }
+
+    void render(const std::vector<Segment>& schedule, double bpm, int totalBars,
+                int barsPerSeg, juce::AudioBuffer<float>& out, std::atomic<bool>& cancelFlag)
+    {
+        const int tgtLen = barsToSamples(totalBars, bpm);
+        out.setSize(2, tgtLen, false, true, true);
+        out.clear();
+
+        const int segLenTgt = barsToSamples(barsPerSeg, bpm);
+        const int xfade = (int) (0.02 * sr);
+
+        juce::AudioBuffer<float> tmp(2, segLenTgt + xfade * 2);
+
+        int cursor = 0;
+        for (size_t i = 0; i < schedule.size(); ++i)
+        {
+            if (cancelFlag.load()) return;
+            renderStretchedSegment(schedule[i], segLenTgt + (i==0?xfade:2*xfade), tmp);
+            const int writeStart = juce::jmax(0, cursor - xfade);
+            const int readStart  = (i==0?0:xfade);
+            const int writeLen   = juce::jmin(out.getNumSamples() - writeStart, tmp.getNumSamples() - readStart);
+
+            for (int n = 0; n < writeLen; ++n)
+            {
+                float w = 1.0f;
+                const int pos = n + writeStart - cursor + xfade;
+                if (pos < xfade) w = (float)pos / (float)xfade;
+                else if (pos > (segLenTgt + xfade)) w = 1.0f - (float)(pos - (segLenTgt + xfade)) / (float)xfade;
+
+                for (int ch = 0; ch < out.getNumChannels(); ++ch)
+                {
+                    float a = out.getSample(ch, writeStart + n);
+                    float b = tmp.getSample(juce::jmin(ch, tmp.getNumChannels()-1), readStart + n);
+                    out.setSample(ch, writeStart + n, a * (1.0f - w) + b * w);
+                }
+            }
+
+            cursor += segLenTgt;
+            if (cursor >= out.getNumSamples() || cancelFlag.load()) break;
+        }
+    }
+
+private:
+    double sr = 48000.0;
+
+    int barsToSamples(int bars, double bpm) const
+    {
+        const double sec = bars * 4.0 * 60.0 / bpm;
+        return (int) std::round(sec * sr);
+    }
+
+    void renderStretchedSegment(const Segment& s, int targetLen, juce::AudioBuffer<float>& dst)
+    {
+#ifdef SAMURISE_USE_RUBBERBAND
+        RubberBand::RubberBandStretcher stretcher(sr, 1,
+            RubberBand::RubberBandStretcher::OptionProcessRealTime);
+        stretcher.setTimeRatio((double)targetLen / (double)s.length);
+        juce::AudioBuffer<float> mono(1, s.length);
+        for (int ch = 0; ch < s.src->getNumChannels(); ++ch)
+            mono.addFrom(0, 0, *s.src, ch, s.start, s.length, 1.0f / juce::jmax(1, s.src->getNumChannels()));
+        stretcher.process(mono.getArrayOfReadPointers(), s.length, false);
+        juce::AudioBuffer<float> outBuf(1, targetLen);
+        stretcher.retrieve(outBuf.getArrayOfWritePointers(), targetLen);
+        dst.makeCopyOf(outBuf, true);
+        dst.setSize(2, targetLen, true, true, true);
+        dst.copyFrom(1, 0, dst, 0, 0, targetLen); // duplicate mono to stereo
+#else
+        const int grain = (int)(0.08 * sr);
+        const int hopIn = grain / 2;
+        const int hopOut = grain / 3;
+        const float rate = (float) s.length / (float) targetLen;
+
+        dst.setSize(2, targetLen);
+        dst.clear();
+
+        juce::AudioBuffer<float> mono(1, s.length);
+        mono.clear();
+        for (int ch = 0; ch < s.src->getNumChannels(); ++ch)
+            mono.addFrom(0, 0, *s.src, ch, s.start, s.length, 1.0f / juce::jmax(1, s.src->getNumChannels()));
+
+        int srcPos = 0, dstPos = 0;
+        juce::AudioBuffer<float> g(1, grain);
+        while (dstPos + grain < dst.getNumSamples() && srcPos + grain < mono.getNumSamples())
+        {
+            for (int i = 0; i < grain; ++i)
+            {
+                const float x = (srcPos + (int)(i * rate));
+                const int   i0 = juce::jlimit(0, mono.getNumSamples()-2, (int)x);
+                const float t  = x - (float)i0;
+                const float s0 = mono.getSample(0, i0);
+                const float s1 = mono.getSample(0, i0+1);
+                g.setSample(0, i, s0 + (s1 - s0) * t);
+            }
+            for (int i = 0; i < grain; ++i)
+            {
+                const float w = hann((float)i / (float)(grain-1));
+                const float v = g.getSample(0, i) * w;
+                for (int ch = 0; ch < dst.getNumChannels(); ++ch)
+                {
+                    const int p = dstPos + i;
+                    if (p < dst.getNumSamples())
+                        dst.addSample(ch, p, v * 0.7f);
+                }
+            }
+            srcPos += hopIn;
+            dstPos += hopOut;
+        }
+#endif
+    }
+};
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioEditor.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioEditor.cpp
@@ -1,0 +1,216 @@
+#include "SamuRiserAudioEditor.h"
+#include "SamuRiserAudioProcessor.h"
+
+SamuRiserAudioEditor::SamuRiserAudioEditor(SamuRiserAudioProcessor& p, juce::AudioProcessorValueTreeState& s)
+    : AudioProcessorEditor(p), processor(p), apvts(s)
+{
+    using namespace juce;
+
+    // apply a dark theme so the interface looks consistent across hosts
+    lookAndFeel.setColour(Slider::thumbColourId, Colours::orange);
+    lookAndFeel.setColour(Slider::rotarySliderFillColourId, Colours::darkgrey);
+    lookAndFeel.setColour(ProgressBar::foregroundColourId, Colours::yellow);
+    setLookAndFeel(&lookAndFeel);
+
+    const float scale = juce::Desktop::getInstance().getGlobalScaleFactor();
+    auto setupSlider = [scale](Slider& s, const juce::String& tip)
+    {
+        s.setSliderStyle(Slider::Rotary);
+        s.setTextBoxStyle(Slider::TextBoxBelow, false, int(60 * scale), int(20 * scale));
+        s.setTooltip(tip);
+    };
+
+    addAndMakeVisible(bpmSlider);
+    setupSlider(bpmSlider, "Beats per minute");
+    bpmAtt = std::make_unique<AudioProcessorValueTreeState::SliderAttachment>(apvts, "bpm", bpmSlider);
+
+    addAndMakeVisible(barsSlider);
+    setupSlider(barsSlider, "Loop length in bars");
+    barsAtt = std::make_unique<AudioProcessorValueTreeState::SliderAttachment>(apvts, "bars", barsSlider);
+
+    addAndMakeVisible(keyNoteBox);
+    keyNoteBox.addItemList({"C","C#","D","D#","E","F","F#","G","G#","A","A#","B"}, 1);
+    keyNoteBox.setTooltip("Key root note");
+    keyNoteAtt = std::make_unique<AudioProcessorValueTreeState::ComboBoxAttachment>(apvts, "keyNote", keyNoteBox);
+
+    addAndMakeVisible(keyModeBox);
+    keyModeBox.addItemList({"Major","Minor"}, 1);
+    keyModeBox.setTooltip("Scale mode");
+    keyModeAtt = std::make_unique<AudioProcessorValueTreeState::ComboBoxAttachment>(apvts, "keyMode", keyModeBox);
+
+    addAndMakeVisible(flavorBox);
+    flavorBox.addItemList({"Granular","Spectral","Hybrid"}, 1);
+    flavorBox.setTooltip("Processing flavor");
+    flavorAtt = std::make_unique<AudioProcessorValueTreeState::ComboBoxAttachment>(apvts, "flavor", flavorBox);
+
+    addAndMakeVisible(humanizeToggle);
+    humanizeToggle.setTooltip("Adds timing jitter");
+    humanizeAtt = std::make_unique<AudioProcessorValueTreeState::ButtonAttachment>(apvts, "humanize", humanizeToggle);
+
+    addAndMakeVisible(densitySlider);
+    setupSlider(densitySlider, "Simultaneous grains");
+    densityAtt = std::make_unique<AudioProcessorValueTreeState::SliderAttachment>(apvts, "density", densitySlider);
+
+    addAndMakeVisible(textureSlider);
+    setupSlider(textureSlider, "Transient vs pad bias");
+    textureAtt = std::make_unique<AudioProcessorValueTreeState::SliderAttachment>(apvts, "texture", textureSlider);
+
+    addAndMakeVisible(mixSlider);
+    setupSlider(mixSlider, "Hybrid blend");
+    mixAtt = std::make_unique<AudioProcessorValueTreeState::SliderAttachment>(apvts, "hybridMix", mixSlider);
+
+    addAndMakeVisible(rebuildButton);
+    addAndMakeVisible(cancelButton);
+    addAndMakeVisible(exportButton);
+    addAndMakeVisible(saveButton);
+    addAndMakeVisible(loadButton);
+    rebuildButton.addListener(this);
+    cancelButton.addListener(this);
+    exportButton.addListener(this);
+    saveButton.addListener(this);
+    loadButton.addListener(this);
+    rebuildButton.setTooltip("Rebuild loop");
+    cancelButton.setTooltip("Cancel rebuild");
+    exportButton.setTooltip("Export loop to WAV");
+    saveButton.setTooltip("Save preset");
+    loadButton.setTooltip("Load preset");
+
+    addAndMakeVisible(poolLabel);
+    poolLabel.setText("Pool: 0", juce::dontSendNotification);
+
+    addAndMakeVisible(progressBar);
+    progressBar.setVisible(false);
+    cancelButton.setEnabled(false);
+    progressBar.setTooltip("Rebuild progress");
+    addAndMakeVisible(levelBar);
+    levelBar.setTooltip("Output level");
+    addAndMakeVisible(grainBar);
+    grainBar.setTooltip("Active grains");
+    startTimerHz(20);
+
+    setResizable(true, true);
+    setResizeLimits(400, 250, 1200, 900);
+    setSize(600, 400);
+}
+
+SamuRiserAudioEditor::~SamuRiserAudioEditor()
+{
+    setLookAndFeel(nullptr);
+}
+
+void SamuRiserAudioEditor::paint(juce::Graphics& g)
+{
+    g.fillAll(juce::Colours::black);
+}
+
+void SamuRiserAudioEditor::resized()
+{
+    auto area = getLocalBounds().reduced(10);
+    auto rowH = area.getHeight() / 3;
+    auto top = area.removeFromTop(rowH);
+    auto mid = area.removeFromTop(rowH);
+    auto bottom = area;
+
+    auto cellWTop = top.getWidth() / 4;
+    bpmSlider.setBounds(top.removeFromLeft(cellWTop));
+    barsSlider.setBounds(top.removeFromLeft(cellWTop));
+    keyNoteBox.setBounds(top.removeFromLeft(cellWTop));
+    keyModeBox.setBounds(top.removeFromLeft(cellWTop));
+
+    auto cellWMid = mid.getWidth() / 5;
+    densitySlider.setBounds(mid.removeFromLeft(cellWMid));
+    textureSlider.setBounds(mid.removeFromLeft(cellWMid));
+    mixSlider.setBounds(mid.removeFromLeft(cellWMid));
+    flavorBox.setBounds(mid.removeFromLeft(cellWMid));
+    humanizeToggle.setBounds(mid.removeFromLeft(cellWMid));
+
+    const float scale = juce::Desktop::getInstance().getGlobalScaleFactor();
+    const int bottomHeight = juce::roundToInt(30 * scale);
+    bottom.reduce(0, bottom.getHeight() - bottomHeight);
+    poolLabel.setBounds(bottom.removeFromLeft(juce::roundToInt(150 * scale)));
+    grainBar.setBounds(bottom.removeFromLeft(juce::roundToInt(80 * scale)));
+    levelBar.setBounds(bottom.removeFromLeft(juce::roundToInt(80 * scale)));
+    exportButton.setBounds(bottom.removeFromRight(juce::roundToInt(100 * scale)));
+    rebuildButton.setBounds(bottom.removeFromRight(juce::roundToInt(100 * scale)));
+    saveButton.setBounds(bottom.removeFromRight(juce::roundToInt(80 * scale)));
+    loadButton.setBounds(bottom.removeFromRight(juce::roundToInt(80 * scale)));
+    cancelButton.setBounds(bottom.removeFromRight(juce::roundToInt(100 * scale)));
+    progressBar.setBounds(bottom);
+}
+
+void SamuRiserAudioEditor::filesDropped(const juce::StringArray& files, int, int)
+{
+    for (const auto& f : files)
+    {
+        poolLabel.setText("Importing...", juce::dontSendNotification);
+        if (auto r = processor.addFile(juce::File(f)); r.failed())
+            juce::AlertWindow::showMessageBoxAsync(juce::MessageBoxIconType::Warning,
+                                                  "Import failed",
+                                                  r.getErrorMessage());
+    }
+
+    poolLabel.setText("Pool: " + juce::String(processor.getPoolSize()), juce::dontSendNotification);
+}
+
+void SamuRiserAudioEditor::buttonClicked(juce::Button* b)
+{
+    if (b == &rebuildButton)
+    {
+        poolLabel.setText("Rebuilding...", juce::dontSendNotification);
+        rebuildButton.setEnabled(false);
+        cancelButton.setEnabled(true);
+        progressValue = 0.0;
+        progressBar.setVisible(true);
+        const double bpm = *apvts.getRawParameterValue("bpm");
+        const int bars = (int)*apvts.getRawParameterValue("bars");
+        const int keyNote = (int)*apvts.getRawParameterValue("keyNote");
+        const bool minor = ((int)*apvts.getRawParameterValue("keyMode")) == 1;
+        processor.rebuildLoopAsync(bpm, bars, 2, minor, keyNote);
+    }
+    else if (b == &cancelButton)
+    {
+        processor.cancelRebuild();
+        progressBar.setVisible(false);
+        rebuildButton.setEnabled(true);
+        cancelButton.setEnabled(false);
+        poolLabel.setText("Pool: " + juce::String(processor.getPoolSize()), juce::dontSendNotification);
+    }
+    else if (b == &exportButton)
+    {
+        juce::FileChooser chooser("Export Loop", juce::File(), "*.wav");
+        if (chooser.browseForFileToSave(true))
+        {
+            auto r = processor.exportLoopToFile(chooser.getResult());
+            if (r.failed())
+                juce::AlertWindow::showMessageBoxAsync(juce::MessageBoxIconType::Warning,
+                                                      "Export failed",
+                                                      r.getErrorMessage());
+        }
+    }
+    else if (b == &saveButton)
+    {
+        juce::FileChooser chooser("Save Preset", juce::File(), "*.xml");
+        if (chooser.browseForFileToSave(true))
+            processor.savePreset(chooser.getResult());
+    }
+    else if (b == &loadButton)
+    {
+        juce::FileChooser chooser("Load Preset", juce::File(), "*.xml");
+        if (chooser.browseForFileToOpen())
+            processor.loadPreset(chooser.getResult());
+    }
+}
+
+void SamuRiserAudioEditor::timerCallback()
+{
+    progressValue = processor.getRebuildProgress();
+    if (! processor.isRebuilding())
+    {
+        progressBar.setVisible(false);
+        rebuildButton.setEnabled(true);
+        cancelButton.setEnabled(false);
+        poolLabel.setText("Pool: " + juce::String(processor.getPoolSize()), juce::dontSendNotification);
+    }
+    levelValue = processor.getOutputLevel();
+    grainValue = (double)processor.getActiveGrains() / 64.0;
+}

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioEditor.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioEditor.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+
+class SamuRiserAudioProcessor;
+
+class SamuRiserAudioEditor : public juce::AudioProcessorEditor,
+                            private juce::FileDragAndDropTarget,
+                            private juce::Button::Listener,
+                            private juce::Timer
+{
+public:
+    SamuRiserAudioEditor(SamuRiserAudioProcessor&, juce::AudioProcessorValueTreeState&);
+    ~SamuRiserAudioEditor() override;
+
+    void paint(juce::Graphics&) override;
+    void resized() override;
+
+    bool isInterestedInFileDrag(const juce::StringArray&) override { return true; }
+    void filesDropped(const juce::StringArray& files, int, int) override;
+    void buttonClicked(juce::Button*) override;
+    void timerCallback() override;
+
+private:
+    SamuRiserAudioProcessor& processor;
+    juce::AudioProcessorValueTreeState& apvts;
+
+    juce::Slider bpmSlider, barsSlider, densitySlider, textureSlider, mixSlider;
+    juce::ComboBox keyNoteBox, keyModeBox, flavorBox;
+    juce::ToggleButton humanizeToggle {"Humanize"};
+    juce::TextButton rebuildButton {"Rebuild"}, cancelButton {"Cancel"},
+                     exportButton {"Export"},
+                     saveButton {"Save"}, loadButton {"Load"};
+    juce::Label poolLabel;
+    double progressValue = 0.0;
+    juce::ProgressBar progressBar {progressValue};
+    double levelValue = 0.0;
+    juce::ProgressBar levelBar {levelValue};
+    double grainValue = 0.0;
+    juce::ProgressBar grainBar {grainValue};
+
+    // simple dark look and feel for consistent theming
+    juce::LookAndFeel_V4 lookAndFeel;
+
+    std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> bpmAtt, barsAtt, densityAtt, textureAtt, mixAtt;
+    std::unique_ptr<juce::AudioProcessorValueTreeState::ComboBoxAttachment> keyNoteAtt, keyModeAtt, flavorAtt;
+    std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment> humanizeAtt;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SamuRiserAudioEditor)
+};

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioProcessor.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioProcessor.cpp
@@ -1,0 +1,550 @@
+#include "SamuRiserAudioProcessor.h"
+#include "SamuRiserAudioEditor.h"
+#include <thread>
+
+//==============================================================================
+SamuRiserAudioProcessor::SamuRiserAudioProcessor()
+    : apvts(*this, nullptr, "PARAMS", createParameterLayout())
+{
+    formatManager.registerBasicFormats();
+}
+
+SamuRiserAudioProcessor::~SamuRiserAudioProcessor()
+{
+    cancelRebuild();
+}
+
+//==============================================================================
+// Analysis of a single audio file. This routine intentionally favours clarity
+// over efficiency as it is intended only as a lightweight, offline analysis
+// used when files are added to the pool.
+void SourceFile::analyze()
+{
+    // Reset previous analysis results in case this file is re-analysed
+    onsets.clear();
+    pitchHist.fill(0);
+    rms = 0.0f;
+
+    const int numChannels = audio.getNumChannels();
+    const int numSamples  = audio.getNumSamples();
+    if (numChannels == 0 || numSamples == 0)
+        return;
+
+    // Mix the input down to mono for analysis.
+    std::vector<float> mono (numSamples, 0.0f);
+    for (int ch = 0; ch < numChannels; ++ch)
+    {
+        const float* src = audio.getReadPointer (ch);
+        for (int i = 0; i < numSamples; ++i)
+            mono[i] += src[i];
+    }
+    const float invCh = 1.0f / static_cast<float> (numChannels);
+    for (auto& s : mono)
+        s *= invCh;
+
+    //=========================================================================
+    // RMS calculation
+    double sumSq = 0.0;
+    for (float s : mono)
+        sumSq += static_cast<double> (s) * static_cast<double> (s);
+    rms = std::sqrt (sumSq / static_cast<double> (numSamples));
+
+    //=========================================================================
+    // Simple onset detection. We apply a naïve first order high‑pass filter and
+    // look for sharp increases in short‑term energy. The window is derived from
+    // the file's sample rate so that timing remains consistent across sources.
+    const int window = juce::jmax(1, (int)std::round(0.01 * sampleRate));
+    std::vector<float> hp (numSamples, 0.0f);
+    float prev = 0.0f;
+    for (int i = 0; i < numSamples; ++i)
+    {
+        const float x = mono[i];
+        hp[i] = x - prev; // differentiator acts as a crude high‑pass filter
+        prev = x;
+    }
+
+    std::vector<float> energy (numSamples, 0.0f);
+    double env = 0.0;
+    for (int i = 0; i < numSamples; ++i)
+    {
+        const float e = hp[i] * hp[i];
+        env += e;
+        if (i >= window)
+            env -= hp[i - window] * hp[i - window];
+        energy[i] = static_cast<float> (env / window);
+    }
+
+    // Pick simple peaks that cross an energy threshold.
+    const float threshold = rms * rms * 4.0f; // scale by RMS to be level independent
+    for (int i = 1; i < numSamples - 1; ++i)
+    {
+        if (energy[i] > threshold && energy[i] > energy[i - 1] && energy[i] > energy[i + 1])
+            onsets.push_back (i);
+    }
+
+    //=========================================================================
+    // Pitch class histogram. We analyse successive FFT frames and vote for the
+    // dominant bin's pitch class. This gives a rough idea of the file's overall
+    // harmonic content and is used as a guideline for key‑aware granulation.
+    const int fftOrder = 11; // 2048‑point FFT
+    const int fftSize  = 1 << fftOrder;
+    juce::dsp::FFT fft (fftOrder);
+    juce::HeapBlock<float> fftData (2 * fftSize);
+    juce::dsp::WindowingFunction<float> windowFn (fftSize, juce::dsp::WindowingFunction<float>::hann);
+
+    for (int pos = 0; pos + fftSize < numSamples; pos += fftSize / 2)
+    {
+        float* re = fftData.get();
+        float* im = re + fftSize;
+        std::fill (re, re + fftSize, 0.0f);
+        std::fill (im, im + fftSize, 0.0f);
+
+        for (int i = 0; i < fftSize; ++i)
+            re[i] = mono[pos + i];
+
+        windowFn.multiplyWithWindowingTable (re, fftSize);
+        fft.perform (re, im, false);
+
+        int maxIndex = 0;
+        float maxMag = 0.0f;
+        for (int i = 0; i < fftSize / 2; ++i)
+        {
+            const float mag = std::sqrt (re[i] * re[i] + im[i] * im[i]);
+            if (mag > maxMag)
+            {
+                maxMag = mag;
+                maxIndex = i;
+            }
+        }
+
+        if (maxMag > 1.0e-6f)
+        {
+            const float freq = (static_cast<float> (maxIndex) * static_cast<float> (sampleRate)) / static_cast<float> (fftSize);
+            const float midi = 69.0f + 12.0f * std::log2 (freq / 440.0f);
+            const int   pc   = ((static_cast<int> (std::round (midi)) % 12) + 12) % 12;
+            ++pitchHist[(size_t) pc];
+        }
+    }
+}
+
+//==============================================================================
+juce::Result SamuRiserAudioProcessor::addFile (const juce::File& file)
+{
+    if (! file.existsAsFile())
+    {
+        auto msg = "File does not exist: " + file.getFullPathName();
+        juce::Logger::writeToLog(msg);
+        return juce::Result::fail(msg);
+    }
+
+    std::unique_ptr<juce::AudioFormatReader> reader (formatManager.createReaderFor (file));
+    if (reader == nullptr)
+    {
+        auto msg = "Unsupported or unreadable file: " + file.getFullPathName();
+        juce::Logger::writeToLog(msg);
+        return juce::Result::fail(msg);
+    }
+
+    auto src = std::make_shared<SourceFile>();
+
+    juce::AudioBuffer<float> temp;
+    temp.setSize ((int) reader->numChannels, (int) reader->lengthInSamples);
+    reader->read (&temp, 0, (int) reader->lengthInSamples, 0, true, true);
+
+    double hostSR = getSampleRate();
+    if (hostSR > 0.0 && std::abs (reader->sampleRate - hostSR) > 1.0)
+    {
+        const double ratio = reader->sampleRate / hostSR;
+        const int destSamples = (int) std::ceil ((double) temp.getNumSamples() / ratio);
+        src->audio.setSize (temp.getNumChannels(), destSamples);
+
+        for (int ch = 0; ch < temp.getNumChannels(); ++ch)
+        {
+            juce::LagrangeInterpolator interp;
+            interp.process (ratio, temp.getReadPointer (ch), src->audio.getWritePointer (ch), destSamples);
+        }
+
+        src->sampleRate = hostSR;
+    }
+    else
+    {
+        src->audio = temp;
+        src->sampleRate = reader->sampleRate;
+    }
+
+    src->analyze();
+
+    auto newPool = std::make_shared<Pool>(*pool.load());
+    newPool->emplace_back(src);
+    pool.store(newPool);
+    engine.setPool(newPool);
+    return juce::Result::ok();
+}
+
+//==============================================================================
+void SamuRiserAudioProcessor::prepareToPlay (double sampleRate, int)
+{
+    analyzer = std::make_unique<SegmentAnalyzer>();
+    renderer = std::make_unique<SegmentGluedRenderer>();
+    renderer->setSampleRate(sampleRate);
+    engine.setSampleRate(sampleRate);
+    engine.setPool(pool.load());
+    spectralEngine.setSampleRate(sampleRate);
+    hybridEngine.setSampleRate(sampleRate);
+    specCutoffSmoothed.reset(sampleRate, 0.05);
+    hybridMixSmoothed.reset(sampleRate, 0.05);
+    specCutoffSmoothed.setCurrentAndTargetValue(*apvts.getRawParameterValue("specCutoff"));
+    hybridMixSmoothed.setCurrentAndTargetValue(*apvts.getRawParameterValue("hybridMix"));
+    playHead = 0;
+
+    juce::dsp::ProcessSpec spec { sampleRate, 512, (juce::uint32)getTotalNumOutputChannels() };
+    tiltEq.prepare(spec);
+    *tiltEq.get<0>().state = *juce::dsp::IIR::Coefficients<float>::makeLowShelf(sampleRate, 1000.0, 0.707f,
+                                                                               juce::Decibels::decibelsToGain(-1.0f));
+    *tiltEq.get<1>().state = *juce::dsp::IIR::Coefficients<float>::makeHighShelf(sampleRate, 1000.0, 0.707f,
+                                                                               juce::Decibels::decibelsToGain(1.0f));
+    limiter.prepare(spec);
+}
+
+//==============================================================================
+void SamuRiserAudioProcessor::rebuildLoop(double bpm, int totalBars, int barsPerSeg,
+                                         bool minorMode, int keyRoot)
+{
+    if (analyzer == nullptr || renderer == nullptr)
+        return;
+
+      MatchSettings ms;
+      ms.barsPerSeg = barsPerSeg;
+      ms.scale = minorMode ? ScaleMask::makeMinor(keyRoot)
+                           : ScaleMask::makeMajor(keyRoot);
+
+      auto poolCopy = *pool.load();
+
+      std::vector<std::vector<Segment>> pools;
+      for (size_t i = 0; i < poolCopy.size(); ++i)
+      {
+          if (cancelRebuildFlag.load()) return;
+          auto& src = poolCopy[i];
+          std::vector<Segment> segs;
+          analyzer->sliceIntoSegments(src->audio, src->sampleRate, bpm, barsPerSeg, segs);
+          pools.push_back(std::move(segs));
+          rebuildProgress = 0.5f * (float)(i + 1) / (float)poolCopy.size();
+      }
+
+    if (cancelRebuildFlag.load()) return;
+
+    auto schedule = matcher.buildSchedule(pools, totalBars, ms);
+    rebuildProgress = 0.75f;
+
+    if (cancelRebuildFlag.load()) return;
+
+    auto newLoop = std::make_shared<juce::AudioBuffer<float>>();
+    newLoop->setSize(2, 1);
+    renderer->render(schedule, bpm, totalBars, barsPerSeg, *newLoop, cancelRebuildFlag);
+    if (cancelRebuildFlag.load()) return;
+    outputLoop.store(newLoop);
+    playHead = 0;
+    rebuildProgress = 1.0f;
+}
+
+void SamuRiserAudioProcessor::cancelRebuild()
+{
+    cancelRebuildFlag = true;
+    if (rebuildThread.joinable())
+        rebuildThread.join();
+    cancelRebuildFlag = false;
+    rebuilding = false;
+    rebuildProgress = 0.0f;
+}
+
+void SamuRiserAudioProcessor::rebuildLoopAsync(double bpm, int totalBars, int barsPerSeg,
+                                              bool minorMode, int keyRoot)
+{
+    cancelRebuild();
+
+    rebuilding = true;
+    rebuildProgress = 0.0f;
+    cancelRebuildFlag = false;
+
+    rebuildThread = std::thread([this, bpm, totalBars, barsPerSeg, minorMode, keyRoot]
+    {
+        rebuildLoop(bpm, totalBars, barsPerSeg, minorMode, keyRoot);
+        rebuilding = false;
+    });
+}
+
+juce::Result SamuRiserAudioProcessor::exportLoopToFile(const juce::File& file)
+{
+    if (! file.hasFileExtension(".wav"))
+        return juce::Result::fail("Only .wav export supported");
+
+    auto loop = outputLoop.load();
+    if (loop->getNumSamples() == 0)
+        return juce::Result::fail("No loop to export");
+    juce::AudioBuffer<float> buffer = *loop; // copy rendered loop
+
+      juce::WavAudioFormat format;
+      std::unique_ptr<juce::FileOutputStream> stream(file.createOutputStream());
+      if (stream == nullptr)
+          return juce::Result::fail("Could not open file for writing");
+
+      std::unique_ptr<juce::AudioFormatWriter> writer(format.createWriterFor(stream.release(),
+                                                                           getSampleRate(),
+                                                                           (unsigned int)buffer.getNumChannels(),
+                                                                           16,
+                                                                           {}, 0));
+      if (writer == nullptr)
+          return juce::Result::fail("Failed to create WAV writer");
+
+      writer->writeFromAudioSampleBuffer(buffer, 0, buffer.getNumSamples());
+      return juce::Result::ok();
+  }
+
+//==============================================================================
+void SamuRiserAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer,
+                                          juce::MidiBuffer&)
+{
+    buffer.clear();
+
+    float bpmParam     = *apvts.getRawParameterValue("bpm");
+    const int bars     = (int)*apvts.getRawParameterValue("bars");
+    const int keyNote  = (int)*apvts.getRawParameterValue("keyNote");
+    const bool isMinor = ((int)*apvts.getRawParameterValue("keyMode")) == 1;
+    const int seed     = (int)*apvts.getRawParameterValue("seed");
+    const float density = *apvts.getRawParameterValue("density");
+    const float texture = *apvts.getRawParameterValue("texture");
+    const bool humanize = (*apvts.getRawParameterValue("humanize")) > 0.5f;
+    const int flavor = (int)*apvts.getRawParameterValue("flavor");
+    const float specCutoff = *apvts.getRawParameterValue("specCutoff");
+    const float hybridMix = *apvts.getRawParameterValue("hybridMix");
+    specCutoffSmoothed.setTargetValue(specCutoff);
+    hybridMixSmoothed.setTargetValue(hybridMix);
+
+    if (auto* ph = getPlayHead())
+    {
+        juce::AudioPlayHead::CurrentPositionInfo info;
+        if (ph->getCurrentPosition(info) && info.bpm > 0.0)
+            bpmParam = (float)info.bpm;
+    }
+
+      if (seed != lastSeed)
+      {
+          engine.setSeed((uint32_t)seed);
+          lastSeed = seed;
+      }
+    engine.setKey(keyNote, isMinor);
+    engine.setDensity(density);
+    engine.setTexture(texture);
+    engine.setHumanize(humanize);
+
+    spectralEngine.setCutoff(specCutoffSmoothed.getNextValue());
+    hybridEngine.setMix(hybridMixSmoothed.getNextValue());
+
+    // Determine dominant pitch class across the pool for spectral shifting
+    float pitchRatio = 1.0f;
+    {
+        auto poolCopy = pool.load();
+        int counts[12]{};
+        for (const auto& src : *poolCopy)
+            for (int i = 0; i < 12; ++i)
+                counts[i] += src->pitchHist[i];
+        int dominant = -1, maxCount = 0;
+        for (int i = 0; i < 12; ++i)
+            if (counts[i] > maxCount) { maxCount = counts[i]; dominant = i; }
+        if (maxCount > 0)
+        {
+            int diff = keyNote - dominant;
+            while (diff > 6) diff -= 12;
+            while (diff < -6) diff += 12;
+            pitchRatio = std::pow(2.0f, diff / 12.0f);
+        }
+    }
+    spectralEngine.setPitchRatio(pitchRatio);
+    hybridEngine.setPitchRatio(pitchRatio);
+
+    switch (flavor)
+    {
+        case 1:
+        {
+            auto loop = outputLoop.load();
+            if (loop && loop->getNumSamples() > 0)
+            {
+                for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+                    for (int n = 0; n < buffer.getNumSamples(); ++n)
+                    {
+                        const int p = (playHead + n) % loop->getNumSamples();
+                        const float v = loop->getSample(juce::jmin(ch, loop->getNumChannels()-1), p);
+                        buffer.setSample(ch, n, v);
+                    }
+                playHead = (playHead + buffer.getNumSamples()) % juce::jmax(1, loop->getNumSamples());
+            }
+            else
+            {
+                engine.process(buffer, buffer.getNumSamples(), bpmParam, bars);
+            }
+            spectralEngine.process(buffer, buffer.getNumSamples(), bpmParam, bars);
+            break;
+        }
+        case 2:
+        {
+            auto loop = outputLoop.load();
+            if (loop && loop->getNumSamples() > 0)
+            {
+                for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+                    for (int n = 0; n < buffer.getNumSamples(); ++n)
+                    {
+                        const int p = (playHead + n) % loop->getNumSamples();
+                        const float v = loop->getSample(juce::jmin(ch, loop->getNumChannels()-1), p);
+                        buffer.setSample(ch, n, v);
+                    }
+                playHead = (playHead + buffer.getNumSamples()) % juce::jmax(1, loop->getNumSamples());
+            }
+            else
+            {
+                engine.process(buffer, buffer.getNumSamples(), bpmParam, bars);
+            }
+            hybridEngine.process(buffer, buffer.getNumSamples(), bpmParam, bars);
+            break;
+        }
+        default:
+        {
+            auto loop = outputLoop.load();
+            if (loop && loop->getNumSamples() > 0)
+            {
+                for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+                    for (int n = 0; n < buffer.getNumSamples(); ++n)
+                    {
+                        const int p = (playHead + n) % loop->getNumSamples();
+                        const float v = loop->getSample(juce::jmin(ch, loop->getNumChannels()-1), p);
+                        buffer.setSample(ch, n, v);
+                    }
+                playHead = (playHead + buffer.getNumSamples()) % juce::jmax(1, loop->getNumSamples());
+            }
+            else
+            {
+                engine.process(buffer, buffer.getNumSamples(), bpmParam, bars);
+            }
+            break;
+        }
+    }
+
+    const bool bypassBus = (*apvts.getRawParameterValue("busBypass")) > 0.5f;
+    if (! bypassBus)
+    {
+        juce::dsp::AudioBlock<float> block(buffer);
+        juce::dsp::ProcessContextReplacing<float> ctx(block);
+        tiltEq.process(ctx);
+
+        // Apply stereo width control.  Instead of clamping the side channel,
+        // scale it to narrow or widen the stereo image.  A width of 0.0
+        // collapses to mono; 1.0 preserves the original side level.
+        float widthAmount = *apvts.getRawParameterValue("width");
+        if (buffer.getNumChannels() >= 2)
+        {
+            auto* left = buffer.getWritePointer(0);
+            auto* right = buffer.getWritePointer(1);
+            for (int i = 0; i < buffer.getNumSamples(); ++i)
+            {
+                float mid  = 0.5f * (left[i] + right[i]);
+                float side = 0.5f * (left[i] - right[i]);
+                side *= widthAmount;
+                left[i]  = mid + side;
+                right[i] = mid - side;
+            }
+        }
+
+        if ((*apvts.getRawParameterValue("limiter")) > 0.5f)
+        {
+            limiter.setThreshold(*apvts.getRawParameterValue("limitThresh"));
+            limiter.process(ctx);
+        }
+    }
+
+    const float ceiling = juce::Decibels::decibelsToGain(-1.0f);
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+    {
+        auto* data = buffer.getWritePointer(ch);
+        for (int i = 0; i < buffer.getNumSamples(); ++i)
+            data[i] = juce::jlimit(-ceiling, ceiling, data[i]);
+    }
+
+    // compute RMS level for UI feedback
+    double sum = 0.0;
+    const int total = buffer.getNumChannels() * buffer.getNumSamples();
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+    {
+        const float* data = buffer.getReadPointer(ch);
+        for (int i = 0; i < buffer.getNumSamples(); ++i)
+        {
+            float v = data[i];
+            sum += (double)v * (double)v;
+        }
+    }
+    outputLevel = (float)std::sqrt(sum / std::max(1, total));
+}
+
+juce::Result SamuRiserAudioProcessor::savePreset(const juce::File& file)
+{
+    if (auto xml = apvts.copyState().createXml())
+    {
+        if (xml->writeTo(file))
+            return juce::Result::ok();
+    }
+    return juce::Result::fail("Failed to save preset");
+}
+
+juce::Result SamuRiserAudioProcessor::loadPreset(const juce::File& file)
+{
+    juce::XmlDocument doc(file);
+    std::unique_ptr<juce::XmlElement> xml(doc.getDocumentElement());
+    if (xml == nullptr)
+        return juce::Result::fail("Invalid preset file");
+
+    apvts.replaceState(juce::ValueTree::fromXml(*xml));
+    return juce::Result::ok();
+}
+
+juce::AudioProcessorEditor* SamuRiserAudioProcessor::createEditor()
+{
+    return new SamuRiserAudioEditor(*this, apvts);
+}
+
+juce::AudioProcessorValueTreeState::ParameterLayout SamuRiserAudioProcessor::createParameterLayout()
+{
+    using namespace juce;
+    std::vector<std::unique_ptr<RangedAudioParameter>> params;
+    params.emplace_back(std::make_unique<AudioParameterFloat>("bpm", "BPM", NormalisableRange<float>(20.f, 300.f, 0.01f), 140.f));
+    params.emplace_back(std::make_unique<AudioParameterInt>("bars", "Bars", 1, 128, 16));
+    params.emplace_back(std::make_unique<AudioParameterChoice>("keyNote", "Key Note", StringArray{"C","C#","D","D#","E","F","F#","G","G#","A","A#","B"}, 9));
+    params.emplace_back(std::make_unique<AudioParameterChoice>("keyMode", "Mode", StringArray{"Major","Minor"}, 1));
+    params.emplace_back(std::make_unique<AudioParameterInt>("seed", "Seed", 0, 1'000'000, 42));
+    params.emplace_back(std::make_unique<AudioParameterFloat>("density", "Density", NormalisableRange<float>(0.f,1.f,0.001f), 0.6f));
+    params.emplace_back(std::make_unique<AudioParameterFloat>("texture", "Texture", NormalisableRange<float>(0.f,1.f,0.001f), 0.5f));
+    params.emplace_back(std::make_unique<AudioParameterChoice>("flavor", "Flavor", StringArray{"Granular","Spectral","Hybrid"}, 0));
+    params.emplace_back(std::make_unique<AudioParameterFloat>("hybridMix", "Hybrid Mix", NormalisableRange<float>(0.f,1.f,0.001f), 0.5f));
+    params.emplace_back(std::make_unique<AudioParameterBool>("humanize", "Humanize", false));
+    params.emplace_back(std::make_unique<AudioParameterFloat>("specCutoff", "Spectral Cutoff",
+                        NormalisableRange<float>(200.f, 20000.f, 1.f, 0.5f), 5000.f));
+    params.emplace_back(std::make_unique<AudioParameterFloat>("width", "Stereo Width", NormalisableRange<float>(0.f,1.f,0.001f), 0.9f));
+    params.emplace_back(std::make_unique<AudioParameterBool>("limiter", "Limiter", true));
+    params.emplace_back(std::make_unique<AudioParameterFloat>("limitThresh", "Limit Threshold", NormalisableRange<float>(-24.f,0.f,0.1f), -1.0f));
+    params.emplace_back(std::make_unique<AudioParameterBool>("busBypass", "Bypass Bus", false));
+    return { params.begin(), params.end() };
+}
+
+void SamuRiserAudioProcessor::getStateInformation(juce::MemoryBlock& destData)
+{
+    if (auto state = apvts.copyState())
+    {
+        juce::MemoryOutputStream stream(destData, false);
+        state.writeToStream(stream);
+    }
+}
+
+void SamuRiserAudioProcessor::setStateInformation(const void* data, int sizeInBytes)
+{
+    juce::ValueTree tree = juce::ValueTree::readFromData(data, sizeInBytes);
+    if (tree.isValid())
+        apvts.replaceState(tree);
+}
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioProcessor.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SamuRiserAudioProcessor.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_dsp/juce_dsp.h>
+#include "SammuMatcher.h"
+#include "GranularEngine.h"
+#include "SpectralEngine.h"
+#include "HybridEngine.h"
+#include <array>
+#include <vector>
+#include <memory>
+#include <atomic>
+#include <thread>
+
+//==============================================================================
+// Represents a single audio file in the pool. Contains basic analysis results
+// that guide the granular engine when selecting regions of the file.
+struct SourceFile
+{
+    juce::AudioBuffer<float> audio;                  // Audio data (mono or stereo)
+    std::vector<int> onsets;                         // Detected onset sample positions
+    std::array<int, 12> pitchHist{};                 // Histogram of pitch classes
+    float rms = 0.0f;                                // Root mean square level
+    double sampleRate = 44100.0;                     // Sample rate of the audio file
+
+    void analyze();                                  // Performs lightweight analysis
+};
+
+//==============================================================================
+// Simplified audio processor that manages the file pool. The actual processor
+// would expose parameters and perform real‑time processing, but for the purpose
+// of this task we only focus on ingesting files and analysing them.
+class SamuRiserAudioEditor;
+
+class SamuRiserAudioProcessor : public juce::AudioProcessor
+{
+public:
+    SamuRiserAudioProcessor();
+    ~SamuRiserAudioProcessor() override;
+
+    // Ingests a new audio file, analyses it and stores it in the pool.
+    // Returns a Result detailing success or the reason for failure so the
+    // caller can surface informative error messages.
+    juce::Result addFile(const juce::File& file);
+
+    //=== JUCE boilerplate =====================================================
+    const juce::String getName() const override { return "SamuRiser"; }
+    double getTailLengthSeconds() const override { return 0.0; }
+    bool acceptsMidi() const override { return false; }
+    bool producesMidi() const override { return false; }
+    void prepareToPlay(double sampleRate, int) override;
+    void releaseResources() override {}
+    bool isBusesLayoutSupported(const BusesLayout&) const override { return true; }
+    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override { return true; }
+    void getStateInformation(juce::MemoryBlock& destData) override;
+    void setStateInformation(const void* data, int sizeInBytes) override;
+
+    // Build/refresh the rendered loop using the segment matcher
+    void rebuildLoop(double bpm, int totalBars, int barsPerSeg,
+                     bool minorMode, int keyRoot);
+    void rebuildLoopAsync(double bpm, int totalBars, int barsPerSeg,
+                          bool minorMode, int keyRoot);
+    void cancelRebuild();
+    float getRebuildProgress() const { return rebuildProgress.load(); }
+    bool isRebuilding() const { return rebuilding.load(); }
+    float getOutputLevel() const { return outputLevel.load(); }
+    int getActiveGrains() const { return engine.getActiveCount(); }
+    juce::Result exportLoopToFile(const juce::File& file);
+    juce::Result savePreset(const juce::File& file);
+    juce::Result loadPreset(const juce::File& file);
+    juce::AudioProcessorValueTreeState& getAPVTS() { return apvts; }
+    int getPoolSize() const { return (int)pool.load()->size(); }
+
+private:
+    juce::AudioProcessorValueTreeState apvts;
+    static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
+
+    juce::AudioFormatManager formatManager;                         // Reads audio files
+    using Pool = std::vector<std::shared_ptr<SourceFile>>;
+    std::atomic<std::shared_ptr<Pool>> pool { std::make_shared<Pool>() }; // lock-free pool
+
+    std::unique_ptr<SegmentAnalyzer> analyzer;                      // Segment analysis
+    std::unique_ptr<SegmentGluedRenderer> renderer;                 // Rendering glue
+    SegmentMatcher matcher;                                         // Segment matcher
+    GranularEngine engine;                                          // Real-time granular engine
+    SpectralEngine spectralEngine;                                  // Spectral stub
+    HybridEngine  hybridEngine;                                     // Hybrid stub
+
+    using Filter = juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>,
+                                                 juce::dsp::IIR::Coefficients<float>>;
+    juce::dsp::ProcessorChain<Filter, Filter> tiltEq;               // simple tilt EQ
+    juce::dsp::Limiter<float> limiter;                              // output limiter
+
+      std::atomic<std::shared_ptr<juce::AudioBuffer<float>>> outputLoop { std::make_shared<juce::AudioBuffer<float>>() }; // rendered loop
+      int playHead = 0;                                               // Playback cursor
+      int lastSeed = -1;                                              // Cache previous seed
+
+      std::atomic<float> rebuildProgress {0.0f};
+      std::atomic<bool> rebuilding {false};
+      std::atomic<float> outputLevel {0.0f};                       // last RMS level
+
+      std::thread rebuildThread;                                      // background rebuild
+      std::atomic<bool> cancelRebuildFlag { false };                  // cancellation flag
+      juce::SmoothedValue<float> specCutoffSmoothed;                  // parameter smoothing
+      juce::SmoothedValue<float> hybridMixSmoothed;
+  };
+

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.cpp
@@ -1,0 +1,120 @@
+#include "SpectralEngine.h"
+
+void SpectralEngine::setSampleRate(double sr)
+{
+    sampleRate = sr;
+#ifdef SAMURISE_USE_RUBBERBAND
+    stretcher.reset(new RubberBand::RubberBandStretcher(
+        sr, 1, RubberBand::RubberBandStretcher::OptionProcessRealTime |
+            RubberBand::RubberBandStretcher::OptionPitchHighConsistency));
+#endif
+}
+
+//==============================================================================
+void SpectralEngine::process(juce::AudioBuffer<float>& buffer, int numSamples,
+                             double, int)
+{
+#ifdef SAMURISE_USE_RUBBERBAND
+    if (stretcher)
+    {
+        stretcher->setPitchScale(pitchRatio);
+        float* chans[2] = {
+            buffer.getWritePointer(0),
+            buffer.getNumChannels() > 1 ? buffer.getWritePointer(1) : buffer.getWritePointer(0)
+        };
+        stretcher->process(chans, (size_t)numSamples, false);
+        stretcher->retrieve(chans, (size_t)numSamples);
+        return;
+    }
+#endif
+
+    const int fftSize = fft.getSize();
+    const int hopSize = fftSize / 4; // 75% overlap for smoother OLA
+
+    if ((int)fftBuffer.size() < 2 * fftSize)
+        fftBuffer.resize(2 * fftSize, 0.0f);
+    if ((int)dest.size() < 2 * fftSize)
+        dest.resize(2 * fftSize, 0.0f);
+    if (accum.getNumSamples() < numSamples + fftSize)
+        accum.setSize(1, numSamples + fftSize, false, false, true);
+    accum.clear();
+
+    const int bins = fftSize / 2;
+    if ((int)prevInPhase.size() < bins + 1)
+    {
+        prevInPhase.assign(bins + 1, 0.0f);
+        prevOutPhase.assign(bins + 1, 0.0f);
+        prevMag.assign(bins + 1, 0.0f);
+    }
+
+    const float freqPerBin = (float)sampleRate / (float)fftSize;
+    const float expPhase = juce::MathConstants<float>::twoPi * hopSize / (float)fftSize;
+
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+    {
+        const float* read = buffer.getReadPointer(ch);
+        for (int pos = 0; pos + fftSize <= numSamples; pos += hopSize)
+        {
+            std::fill(fftBuffer.begin(), fftBuffer.end(), 0.0f);
+            std::memcpy(fftBuffer.data(), read + pos, fftSize * sizeof(float));
+
+            window.multiplyWithWindowingTable(fftBuffer.data(), fftSize);
+            fft.performRealOnlyForwardTransform(fftBuffer.data());
+
+            std::fill(dest.begin(), dest.end(), 0.0f);
+            for (int i = 0; i < bins; ++i)
+            {
+                float freq = i * freqPerBin;
+                if (freq > cutoff) continue;
+
+                float re = fftBuffer[2 * i];
+                float im = fftBuffer[2 * i + 1];
+                float m = std::sqrt(re * re + im * im);
+                float phase = std::atan2(im, re);
+
+                prevMag[i] = 0.7f * prevMag[i] + 0.3f * m;
+
+                float delta = phase - prevInPhase[i];
+                prevInPhase[i] = phase;
+                delta -= expPhase * i;
+                delta = std::fmod(delta + juce::MathConstants<float>::pi,
+                                  juce::MathConstants<float>::twoPi) -
+                        juce::MathConstants<float>::pi;
+                float trueFreq = (i + delta / expPhase) * pitchRatio;
+                int base = (int)trueFreq;
+                float frac = trueFreq - (float)base;
+                if (base < bins)
+                {
+                    float mag = prevMag[i];
+                    float phase0 = prevOutPhase[base] + expPhase * trueFreq;
+                    prevOutPhase[base] = phase0;
+                    float cos0 = std::cos(phase0);
+                    float sin0 = std::sin(phase0);
+                    dest[2 * base]     += mag * (1.0f - frac) * cos0;
+                    dest[2 * base + 1] += mag * (1.0f - frac) * sin0;
+
+                    if (base + 1 < bins)
+                    {
+                        float phase1 = prevOutPhase[base + 1] + expPhase * (trueFreq + 1.0f);
+                        prevOutPhase[base + 1] = phase1;
+                        float cos1 = std::cos(phase1);
+                        float sin1 = std::sin(phase1);
+                        dest[2 * (base + 1)]     += mag * frac * cos1;
+                        dest[2 * (base + 1) + 1] += mag * frac * sin1;
+                    }
+                }
+            }
+
+            fft.performRealOnlyInverseTransform(dest.data());
+            window.multiplyWithWindowingTable(dest.data(), fftSize);
+
+            const float scale = 1.0f / (float)fftSize;
+            for (int i = 0; i < fftSize; ++i)
+                accum.addSample(0, pos + i, dest[i] * scale);
+        }
+
+        float* write = buffer.getWritePointer(ch);
+        for (int i = 0; i < numSamples; ++i)
+            write[i] = accum.getSample(0, i);
+    }
+}

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.h
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/src/SpectralEngine.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#ifdef SAMURISE_USE_RUBBERBAND
+ #include <rubberband/RubberBandStretcher.h>
+#endif
+
+class SpectralEngine
+{
+public:
+    void setSampleRate(double sr);
+    void setCutoff(float c) { cutoff = c; }
+    void setPitchRatio(float r) { pitchRatio = r; }
+
+    // Apply a simple FFT-based low-pass filter or optional Rubber Band pitch shift.
+    // This remains a lightweight placeholder for a true spectral resynthesis engine
+    // and exists to provide a distinct processing path from the granular engine.
+    void process(juce::AudioBuffer<float>& buffer, int numSamples, double, int);
+
+private:
+    double sampleRate = 44100.0;
+    juce::dsp::FFT fft{10};                                   // 1024-point FFT
+    juce::dsp::WindowingFunction<float> window{ (size_t)1024,
+        juce::dsp::WindowingFunction<float>::hann };
+    std::vector<float> fftBuffer;                             // real/imag pairs
+    std::vector<float> prevInPhase;                           // phase vocoder state
+    std::vector<float> prevOutPhase;                          // phase vocoder state
+    std::vector<float> prevMag;                               // magnitude envelope
+    juce::AudioBuffer<float> accum;                           // reuse accumulation buffer
+    std::vector<float> dest;                                  // reused FFT output
+#ifdef SAMURISE_USE_RUBBERBAND
+    std::unique_ptr<RubberBand::RubberBandStretcher> stretcher;
+#endif
+    float cutoff = 5000.0f;                                   // Hz
+    float pitchRatio = 1.0f;
+};

--- a/Driftkind-codex-implement-samuriseaudioprocessor-addfile/tests/test_main.cpp
+++ b/Driftkind-codex-implement-samuriseaudioprocessor-addfile/tests/test_main.cpp
@@ -1,0 +1,235 @@
+#include <juce_core/juce_core.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_dsp/juce_dsp.h>
+#include <atomic>
+#include "../src/SamuRiserAudioProcessor.h"
+#include "../src/GranularEngine.h"
+#include "../src/SpectralEngine.h"
+#include "../src/HybridEngine.h"
+#include "../src/SammuMatcher.h"
+#include <cmath>
+
+struct AnalysisTest : juce::UnitTest {
+    AnalysisTest() : juce::UnitTest("SourceFile Analysis", "Analysis") {}
+    void runTest() override {
+        beginTest("Analysis resets previous results");
+        SourceFile sf; sf.audio.setSize(1, 1024); sf.sampleRate = 48000.0;
+        for (int i = 0; i < sf.audio.getNumSamples(); ++i)
+            sf.audio.setSample(0, i, i % 2 ? 0.5f : -0.5f);
+        sf.analyze();
+        auto onsetCount = (int)sf.onsets.size(); auto hist = sf.pitchHist;
+        sf.analyze();
+        expectEquals((int)sf.onsets.size(), onsetCount);
+        expect(sf.pitchHist == hist);
+
+        beginTest("SegmentAnalyzer handles sub-FFT segments");
+        SegmentAnalyzer analyzer;
+        const double shortFileSR = 44100.0;
+        const double fastBpm = 8000.0;
+        const int barsPerSegment = 1;
+        const int shortSegSamples = (int)std::round(barsPerSegment * 4.0 * (60.0 / fastBpm) * shortFileSR);
+        expect(shortSegSamples < (1 << 11));
+        juce::AudioBuffer<float> shortBuffer;
+        shortBuffer.setSize(1, shortSegSamples);
+        for (int i = 0; i < shortBuffer.getNumSamples(); ++i)
+            shortBuffer.setSample(0, i, std::sin(0.01f * (float)i));
+
+        std::vector<Segment> segments;
+        analyzer.sliceIntoSegments(shortBuffer, shortFileSR, fastBpm, barsPerSegment, segments);
+        expectEquals((int)segments.size(), 1);
+        expectEquals(segments.front().length, shortSegSamples);
+        expect(std::isfinite(segments.front().rms));
+    }
+};
+
+struct GranularEngineTest : juce::UnitTest {
+    GranularEngineTest() : juce::UnitTest("Granular Engine", "DSP") {}
+    void runTest() override {
+        beginTest("snapToScale aligns to key");
+        GranularEngine ge; ge.setKey(9, true);
+        int note = ge.snapToScale(61);
+        expect(note == 60 || note == 62);
+
+        beginTest("process produces audio");
+        ge.setSampleRate(48000.0); ge.setSeed(42); ge.setDensity(1.0f); ge.setTexture(0.0f);
+        std::vector<std::shared_ptr<SourceFile>> pool;
+        auto src = std::make_shared<SourceFile>();
+        src->audio.setSize(1, 48000); src->sampleRate = 48000.0;
+        for (int i = 0; i < src->audio.getNumSamples(); ++i)
+            src->audio.setSample(0, i, std::sin(2.0 * juce::MathConstants<double>::pi * i / 100.0));
+        pool.push_back(src); ge.setPool(&pool);
+        juce::AudioBuffer<float> out; out.setSize(1, 512);
+        ge.process(out, 512, 120.0, 1);
+        bool nonZero = false;
+        for (int i = 0; i < out.getNumSamples(); ++i)
+            if (std::abs(out.getSample(0, i)) > 0.0f) { nonZero = true; break; }
+        expect(nonZero);
+    }
+};
+
+struct MatcherRendererTest : juce::UnitTest {
+    MatcherRendererTest() : juce::UnitTest("Matcher and Renderer", "DSP") {}
+    void runTest() override {
+        beginTest("Matcher builds schedule");
+        Segment a; a.length = 100; a.chroma = {1,0,0,0,0,0,0,0,0,0,0,0}; a.onsetDensity=0.5f; a.rms=0.5f; a.dominantPC=0;
+        Segment b; b.length = 100; b.chroma = {0,1,0,0,0,0,0,0,0,0,0,0}; b.onsetDensity=0.5f; b.rms=0.5f; b.dominantPC=1;
+        std::vector<std::vector<Segment>> pools = {{a},{b}};
+        MatchSettings ms; ms.barsPerSeg = 1; ms.scale = ScaleMask::makeMajor(0);
+        SegmentMatcher matcher; auto schedule = matcher.buildSchedule(pools, 2, ms);
+        expectEquals((int)schedule.size(), 2);
+
+        beginTest("Renderer outputs expected length");
+        juce::AudioBuffer<float> dummy; dummy.setSize(1, 48000);
+        Segment seg; seg.src = &dummy; seg.start = 0; seg.length = 48000; seg.srcSR = 48000.0;
+        SegmentGluedRenderer renderer; renderer.setSampleRate(48000.0);
+        std::vector<Segment> sched = {seg, seg};
+        juce::AudioBuffer<float> loop; std::atomic<bool> cancel(false);
+        renderer.render(sched, 120.0, 2, 1, loop, cancel);
+        expectEquals(loop.getNumSamples(), 192000);
+    }
+};
+
+struct EngineInteropTest : juce::UnitTest {
+    EngineInteropTest() : juce::UnitTest("Engine Interop", "DSP") {}
+    void runTest() override {
+        beginTest("Spectral and Hybrid engines produce audio");
+        SpectralEngine se; se.setSampleRate(48000.0); juce::AudioBuffer<float> buf; buf.setSize(1, 1024);
+        for (int i = 0; i < buf.getNumSamples(); ++i) buf.setSample(0, i, std::sin(0.01f*(float)i));
+        auto copy = buf; se.setPitchRatio(1.0f); se.process(buf, buf.getNumSamples(), 120.0, 1);
+        bool specNonZero=false; double err=0.0; for(int i=0;i<buf.getNumSamples();++i){float v=buf.getSample(0,i); specNonZero|=(v!=0.0f); float d=v-copy.getSample(0,i); err+=d*d;}
+        expect(specNonZero); expectLessThan(std::sqrt(err / buf.getNumSamples()), 0.01);
+
+        HybridEngine he; he.setSampleRate(48000.0);
+        juce::AudioBuffer<float> hbuf; hbuf.setSize(1,512); for(int i=0;i<hbuf.getNumSamples();++i) hbuf.setSample(0,i,std::sin(0.02f*(float)i));
+        he.process(hbuf, hbuf.getNumSamples(), 120.0, 1);
+        bool hybNonZero=false; for(int i=0;i<hbuf.getNumSamples();++i) if(hbuf.getSample(0,i)!=0.0f){hybNonZero=true;break;}
+        expect(hybNonZero);
+    }
+};
+
+struct HybridMixTest : juce::UnitTest {
+    HybridMixTest() : juce::UnitTest("Hybrid mix", "DSP") {}
+    void runTest() override {
+        beginTest("Hybrid mix balances spectral and granular outputs");
+        HybridEngine he; he.setSampleRate(48000.0);
+
+        juce::AudioBuffer<float> input; input.setSize(1, 512);
+        for (int i = 0; i < input.getNumSamples(); ++i)
+            input.setSample(0, i, std::sin(0.01f * (float)i));
+
+        // reference spectral-only output
+        juce::AudioBuffer<float> spectralOnly = input;
+        SpectralEngine se; se.setSampleRate(48000.0); se.setPitchRatio(1.0f);
+        se.process(spectralOnly, spectralOnly.getNumSamples(), 120.0, 1);
+
+        he.setMix(0.0f);
+        juce::AudioBuffer<float> buf = input;
+        he.process(buf, buf.getNumSamples(), 120.0, 1);
+        for (int i = 0; i < buf.getNumSamples(); ++i)
+            expectWithinAbsoluteError(buf.getSample(0, i), spectralOnly.getSample(0, i), 1e-5f);
+
+        he.setMix(1.0f);
+        buf = input;
+        he.process(buf, buf.getNumSamples(), 120.0, 1);
+        for (int i = 0; i < buf.getNumSamples(); ++i)
+            expectWithinAbsoluteError(buf.getSample(0, i), input.getSample(0, i), 1e-5f);
+
+        he.setMix(0.5f);
+        buf = input;
+        he.process(buf, buf.getNumSamples(), 120.0, 1);
+        float specSample = spectralOnly.getSample(0, 0);
+        float drySample = input.getSample(0, 0);
+        expectWithinAbsoluteError(buf.getSample(0, 0), 0.5f * specSample + 0.5f * drySample, 1e-4f);
+    }
+};
+
+struct ResampleTest : juce::UnitTest {
+    ResampleTest() : juce::UnitTest("Processor resampling", "Processor") {}
+    void runTest() override {
+        beginTest("addFile resamples sources to host rate");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        juce::File tmp = juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("sr_test.wav");
+        juce::WavAudioFormat wf; {
+            std::unique_ptr<juce::FileOutputStream> os(tmp.createOutputStream());
+            auto writer = std::unique_ptr<juce::AudioFormatWriter>(wf.createWriterFor(os.release(), 48000, 1, 16, {}, 0));
+            juce::AudioBuffer<float> tb; tb.setSize(1,48000); tb.clear(); writer->writeFromAudioSampleBuffer(tb,0,tb.getNumSamples());
+        }
+        auto res = proc.addFile(tmp); tmp.deleteFile();
+        expect(res.wasOk());
+        expectEquals(proc.getPoolSize(), 1);
+    }
+};
+
+struct EditorTest : juce::UnitTest {
+    EditorTest() : juce::UnitTest("Editor", "UI") {}
+    void runTest() override {
+        beginTest("Processor creates editor");
+        SamuRiserAudioProcessor proc; auto editor = std::unique_ptr<juce::AudioProcessorEditor>(proc.createEditor());
+        expect(editor != nullptr);
+    }
+};
+
+struct PresetTest : juce::UnitTest {
+    PresetTest() : juce::UnitTest("Preset save/load", "Processor") {}
+    void runTest() override {
+        beginTest("Parameters round-trip through preset");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        auto* bpmParam = proc.getAPVTS().getRawParameterValue("bpm");
+        *const_cast<float*>(bpmParam) = 123.0f;
+        juce::File preset = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                                .getChildFile("preset.xml");
+        proc.savePreset(preset);
+        *const_cast<float*>(bpmParam) = 99.0f;
+        proc.loadPreset(preset);
+        preset.deleteFile();
+        expectWithinAbsoluteError(*bpmParam, 123.0f, 0.001f);
+    }
+};
+
+struct ExportErrorTest : juce::UnitTest {
+    ExportErrorTest() : juce::UnitTest("Export errors", "Processor") {}
+    void runTest() override {
+        beginTest("Non-WAV export fails");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        juce::File tmp = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                             .getChildFile("out.txt");
+        auto r = proc.exportLoopToFile(tmp);
+        expect(r.failed());
+    }
+};
+
+static AnalysisTest analysisTest;
+static GranularEngineTest granularTest;
+static MatcherRendererTest matcherRendererTest;
+static EngineInteropTest engineInteropTest;
+static HybridMixTest hybridMixTest;
+static ResampleTest resampleTest;
+static EditorTest editorTest;
+static PresetTest presetTest;
+static ExportErrorTest exportTest;
+struct RebuildCancelTest : juce::UnitTest {
+    RebuildCancelTest() : juce::UnitTest("Rebuild cancel", "Processor") {}
+    void runTest() override {
+        beginTest("Rebuild can be cancelled");
+        SamuRiserAudioProcessor proc; proc.prepareToPlay(44100.0, 512);
+        juce::File tmp = juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("cancel.wav");
+        juce::WavAudioFormat wf; {
+            std::unique_ptr<juce::FileOutputStream> os(tmp.createOutputStream());
+            auto writer = std::unique_ptr<juce::AudioFormatWriter>(wf.createWriterFor(os.release(), 44100, 1, 16, {}, 0));
+            juce::AudioBuffer<float> tb; tb.setSize(1,44100); tb.clear(); writer->writeFromAudioSampleBuffer(tb,0,tb.getNumSamples());
+        }
+        proc.addFile(tmp); tmp.deleteFile();
+        proc.rebuildLoopAsync(120.0, 4, 2, true, 9);
+        proc.cancelRebuild();
+        expect(!proc.isRebuilding());
+    }
+};
+static RebuildCancelTest cancelTest;
+
+int main() {
+    juce::UnitTestRunner runner;
+    runner.runAllTests();
+    return runner.getFailures() > 0 ? 1 : 0;
+}
+


### PR DESCRIPTION
## Summary
- clamp fingerprint frame copy lengths to the available mono samples, zero-padding and normalising with the processed frame count
- skip FFT work when no samples are available in a hop so partial segments no longer trigger invalid memory access
- add a regression unit test that feeds a sub-FFT segment through `SegmentAnalyzer` to ensure analysis succeeds

## Testing
- `cmake -S . -B build -DJUCE_BUILD_EXTRAS=OFF -DJUCE_BUILD_EXAMPLES=OFF`
- `cmake --build build` *(fails: existing project code expects juce::dsp::SmoothedValue and ValueTree usage to compile)*

------
https://chatgpt.com/codex/tasks/task_b_68cd50baa9688320bdd2660eaae846ed